### PR TITLE
updated SteamScript to cache path of manifest file

### DIFF
--- a/Engines/Wine/QuickScript/SteamScript/script.js
+++ b/Engines/Wine/QuickScript/SteamScript/script.js
@@ -36,7 +36,11 @@ SteamScript.prototype.gameOverlay = function(gameOverlay) {
 };
 
 SteamScript.prototype.manifest = function(wine) {
-    return wine.prefixDirectory + "/drive_c/" + wine.programFiles() + "/Steam/steamapps/appmanifest_" + this._appId + ".acf";
+    if (!this._manifest) {
+        // cache manifest path (will not change during the installation)
+        this._manifest = wine.prefixDirectory + "/drive_c/" + wine.programFiles() + "/Steam/steamapps/appmanifest_" + this._appId + ".acf";
+    }
+    return this._manifest;
 };
 
 SteamScript.prototype.downloadStarted = function(wine) {


### PR DESCRIPTION
The path of the manifest file will not change during the installation of a Steam application. Therefore it is sufficient to calculate it once.

fixes #331