### PR TITLE
Codacy: turn off duplication warnings for app scripts

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,6 +1,10 @@
 engines:
   eslint:
     enabled: true
+  duplication:
+    enabled: true
+    exclude_paths:
+      - "Applications/**/*.js'
    
 exclude_paths:
   - '**.po'


### PR DESCRIPTION
As the application scripts all look pretty similar, we get many duplication warnings. The warnings for the Wine scripts etc. are still active as they might provide valid information.