### PR TITLE
Travis: avoid double builds on pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+# avoid double builds on pull requests
+branches:
+  only:
+    master
+
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y python-jsonschema python-pil gettext


### PR DESCRIPTION
If a branch from this repository (not a fork) shall be merged, Travis would execute the checks twice (see e.g. the PRs from crowdin).