### PR TITLE
Mark globals as "exported"

### DIFF
--- a/Engines/Wine/Shortcuts/Reader/script.js
+++ b/Engines/Wine/Shortcuts/Reader/script.js
@@ -67,6 +67,7 @@ var _WineShortcutReader = function(shortcut) {
     }
 };
 
+/* exported ShortcutReader */
 var ShortcutReader = function() {
     var that = this;
 

--- a/Engines/Wine/Shortcuts/Wine/script.js
+++ b/Engines/Wine/Shortcuts/Wine/script.js
@@ -1,5 +1,6 @@
 include(["Engines", "Wine", "Engine", "Object"]);
 
+/* exported WineShortcut */
 var WineShortcut = function () {
     var that = this;
     that._shortcutManager = Bean("shortcutManager");

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -1,3 +1,4 @@
+/* exported AppResource */
 var AppResource = function() {
     var that = this;
     that._appsManager = Bean("repositoryManager");

--- a/Utils/Functions/Filesystem/Extract/script.js
+++ b/Utils/Functions/Filesystem/Extract/script.js
@@ -1,5 +1,6 @@
 include(["Utils", "Functions", "Filesystem", "Files"]);
 
+/* exported CabExtract */
 var CabExtract = function() {
     var that = this;
 
@@ -49,6 +50,7 @@ var CabExtract = function() {
 
 };
 
+/* exported Extractor */
 var Extractor = function () {
     var that = this;
     that._extractor = Bean("extractor");

--- a/Utils/Functions/Filesystem/Files/script.js
+++ b/Utils/Functions/Filesystem/Files/script.js
@@ -6,48 +6,40 @@ var mkdir = function (directoryPath) {
     fileUtilities.mkdir(new java.io.File(directoryPath))
 };
 
-
 /* exported fileExists */
 var fileExists = function (filePath) {
     return new java.io.File(filePath).exists();
 };
-
 
 /* exported cat */
 var cat = function(filePath) {
     return Bean("fileUtilities").getFileContent(new java.io.File(filePath));
 };
 
-
 /* exported cp */
 var cp = function(source, target) {
     return Bean("fileUtilities").copy(new java.io.File(source), new java.io.File(target));
 };
-
 
 /* exported getFileSize */
 var getFileSize = function(filePath) {
     return Bean("fileUtilities").getSize(new java.io.File(filePath));
 };
 
-
 /* exported fileName */
 var fileName = function(filePath) {
     return new java.io.File(filePath).getName();
 };
-
 
 /* exported lns */
 var lns = function(target, destination) {
     return Bean("fileUtilities").createSymbolicLink(new java.io.File(destination), new java.io.File(target));
 };
 
-
 /* exported remove */
 var remove = function(filePath) {
     return Bean("fileUtilities").remove(new java.io.File(filePath));
 };
-
 
 /* exported touch */
 var touch = function(filePath) {
@@ -56,19 +48,16 @@ var touch = function(filePath) {
     }
 };
 
-
 /* exported writeToFile */
 var writeToFile = function(filePath, content) {
     Bean("fileUtilities").writeToFile(new java.io.File(filePath), content);
 };
-
 
 /* exported createTempFile */
 var createTempFile = function (extension) {
     var tmpFile = Bean("fileUtilities").createTmpFile(extension);
     return tmpFile.getAbsolutePath();
 };
-
 
 /* exported Checksum */
 var Checksum = function () {

--- a/Utils/Functions/Filesystem/Files/script.js
+++ b/Utils/Functions/Filesystem/Files/script.js
@@ -1,53 +1,76 @@
 var fileAnalyser = Bean("fileAnalyser");
 var fileUtilities = Bean("fileUtilities");
 
+/* exported mkdir */
 var mkdir = function (directoryPath) {
     fileUtilities.mkdir(new java.io.File(directoryPath))
 };
 
+
+/* exported fileExists */
 var fileExists = function (filePath) {
     return new java.io.File(filePath).exists();
 };
 
+
+/* exported cat */
 var cat = function(filePath) {
     return Bean("fileUtilities").getFileContent(new java.io.File(filePath));
 };
 
+
+/* exported cp */
 var cp = function(source, target) {
     return Bean("fileUtilities").copy(new java.io.File(source), new java.io.File(target));
 };
 
+
+/* exported getFileSize */
 var getFileSize = function(filePath) {
     return Bean("fileUtilities").getSize(new java.io.File(filePath));
 };
 
+
+/* exported fileName */
 var fileName = function(filePath) {
     return new java.io.File(filePath).getName();
 };
 
+
+/* exported lns */
 var lns = function(target, destination) {
     return Bean("fileUtilities").createSymbolicLink(new java.io.File(destination), new java.io.File(target));
 };
 
+
+/* exported remove */
 var remove = function(filePath) {
     return Bean("fileUtilities").remove(new java.io.File(filePath));
 };
 
+
+/* exported touch */
 var touch = function(filePath) {
     if (!fileExists(filePath)) {
         Bean("fileUtilities").writeToFile(new java.io.File(filePath), "");
     }
 };
 
+
+/* exported writeToFile */
 var writeToFile = function(filePath, content) {
     Bean("fileUtilities").writeToFile(new java.io.File(filePath), content);
 };
 
+
+/* exported createTempFile */
 var createTempFile = function (extension) {
     var tmpFile = Bean("fileUtilities").createTmpFile(extension);
     return tmpFile.getAbsolutePath();
 };
 
+
+/* exported Checksum */
 var Checksum = function () {
     var that = this;
     that._method = "SHA";

--- a/Utils/Functions/Net/Download/script.js
+++ b/Utils/Functions/Net/Download/script.js
@@ -1,5 +1,6 @@
 include(["Utils", "Functions", "Filesystem", "Files"]);
 
+/* exported Downloader */
 var Downloader = function () {
     var that = this;
     that._downloader = Bean("downloader");

--- a/Utils/Functions/Net/Resource/script.js
+++ b/Utils/Functions/Net/Resource/script.js
@@ -1,6 +1,7 @@
 include(["Utils", "Functions", "Net", "Download"]);
 include(["Utils", "Functions", "Filesystem", "Files"]);
 
+/* exported Resource */
 var Resource = function () {
     var that = this;
     this._algorithm = "SHA";


### PR DESCRIPTION
fixes ESLint "no-unused-vars" warning for globals

see https://eslint.org/docs/rules/no-unused-vars#exported