### PR TITLE
Remove comments in Messages.properties

### DIFF
--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -7,329 +7,329 @@
 !=Project-Id-Version\: PACKAGE VERSION\nReport-Msgid-Bugs-To\: \nPOT-Creation-Date\: YEAR-MO-DA HO\:MI+ZONE\nPO-Revision-Date\: YEAR-MO-DA HO\:MI+ZONE\nLast-Translator\: FULL NAME <EMAIL@ADDRESS>\nLanguage-Team\: LANGUAGE <LL@li.org>\nLanguage\: \nMIME-Version\: 1.0\nContent-Type\: text/plain; charset\=UTF-8\nContent-Transfer-Encoding\: 8bit\n
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Shower With Your Dad Simulator 2015: Do You Still Shower With Your Dad/application.js:2
-!'Shower\ With\ Your\ Dad\ Simulator\ 2015\:\ Do\ You\ Still\ Shower\ With\ Your\ Dad?'\ is\ a\ fast\ paced\ shower-simulation\ where\ you\ shower\ with\ your\ 8-bit\ dad.\ It's\ good,\ clean\ fun\!=
+'Shower\ With\ Your\ Dad\ Simulator\ 2015\:\ Do\ You\ Still\ Shower\ With\ Your\ Dad?'\ is\ a\ fast\ paced\ shower-simulation\ where\ you\ shower\ with\ your\ 8-bit\ dad.\ It's\ good,\ clean\ fun\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Pro Evolution Soccer 2018/application.js:2
-!'Where\ Legends\ Are\ Made'\ encapsulates\ the\ return\ of\ PES,\ with\ an\ unparalleled\ gameplay\ experience.=
+'Where\ Legends\ Are\ Made'\ encapsulates\ the\ return\ of\ PES,\ with\ an\ unparalleled\ gameplay\ experience.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/dotnet40/script.js:1
-!.NET\ 4.0=
+.NET\ 4.0=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/dotnet45/script.js:1
-!.NET\ 4.5=
+.NET\ 4.5=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/dotnet452/script.js:1
-!.NET\ 4.5.2=
+.NET\ 4.5.2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/18 Wheels of Steel Across America/application.js:1
-!18\ Wheels\ of\ Steel\:\ Across\ America=
+18\ Wheels\ of\ Steel\:\ Across\ America=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/7-zip/application.js:2
-!7-Zip\ is\ a\ file\ archiver\ with\ a\ high\ compression\ ratio.\ 7-Zip\ is\ open\ source\ software.\ Most\ of\ the\ source\ code\ is\ under\ the\ GNU\ LGPL\ license.\ The\ unRAR\ code\ is\ under\ a\ mixed\ license\:\ GNU\ LGPL\ +\ unRAR\ restrictions.\ You\ can\ use\ 7-Zip\ on\ any\ computer,\ including\ a\ computer\ in\ a\ commercial\ organization.\ You\ don't\ need\ to\ register\ or\ pay\ for\ 7-Zip.=
+7-Zip\ is\ a\ file\ archiver\ with\ a\ high\ compression\ ratio.\ 7-Zip\ is\ open\ source\ software.\ Most\ of\ the\ source\ code\ is\ under\ the\ GNU\ LGPL\ license.\ The\ unRAR\ code\ is\ under\ a\ mixed\ license\:\ GNU\ LGPL\ +\ unRAR\ restrictions.\ You\ can\ use\ 7-Zip\ on\ any\ computer,\ including\ a\ computer\ in\ a\ commercial\ organization.\ You\ don't\ need\ to\ register\ or\ pay\ for\ 7-Zip.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/7-zip/application.js:1
-!7-zip=
+7-zip=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Graphics/Photofiltre/application.js:2
-!<b>Introduction</b><br/>PhotoFiltre\ Studio\ is\ a\ complete\ image\ retouching\ program.\ It\ allows\ you\ to\ do\ simple\ or\ advanced\ adjustments\ to\ an\ image\ and\ apply\ a\ vast\ range\ of\ filters\ on\ it.\ It\ is\ simple\ and\ intuitive\ to\ use,\ and\ has\ an\ easy\ learning\ curve.\ The\ toolbar,\ giving\ you\ access\ to\ the\ standard\ filters\ with\ just\ a\ few\ clicks,\ gives\ PhotoFiltre\ Studio\ a\ robust\ look.\ PhotoFiltre\ Studio\ also\ has\ layer\ manager\ (with\ Alpha\ channel),\ advanced\ brushes,\ nozzles\ (or\ tubes),\ red\ eye\ corrector,\ batch\ module\ and\ lot\ of\ other\ powerful\ tools.=
+<b>Introduction</b><br/>PhotoFiltre\ Studio\ is\ a\ complete\ image\ retouching\ program.\ It\ allows\ you\ to\ do\ simple\ or\ advanced\ adjustments\ to\ an\ image\ and\ apply\ a\ vast\ range\ of\ filters\ on\ it.\ It\ is\ simple\ and\ intuitive\ to\ use,\ and\ has\ an\ easy\ learning\ curve.\ The\ toolbar,\ giving\ you\ access\ to\ the\ standard\ filters\ with\ just\ a\ few\ clicks,\ gives\ PhotoFiltre\ Studio\ a\ robust\ look.\ PhotoFiltre\ Studio\ also\ has\ layer\ manager\ (with\ Alpha\ channel),\ advanced\ brushes,\ nozzles\ (or\ tubes),\ red\ eye\ corrector,\ batch\ module\ and\ lot\ of\ other\ powerful\ tools.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/mIRC/application.js:2
-!<p>mIRC\ is\ a\ <b>popular\ Internet\ Relay\ Chat\ client</b>\ used\ by\ millions\ of\ people,\ and\ thousands\ of\ organizations,\ to\ communicate,\ share,\ play\ and\ work\ with\ each\ other\ on\ IRC\ networks\ around\ the\ world.\ Serving\ the\ <b>Internet\ community</b>\ for\ over\ a\ decade,\ mIRC\ has\ evolved\ into\ a\ powerful,\ reliable\ and\ fun\ piece\ of\ technology.<br></p>=
+<p>mIRC\ is\ a\ <b>popular\ Internet\ Relay\ Chat\ client</b>\ used\ by\ millions\ of\ people,\ and\ thousands\ of\ organizations,\ to\ communicate,\ share,\ play\ and\ work\ with\ each\ other\ on\ IRC\ networks\ around\ the\ world.\ Serving\ the\ <b>Internet\ community</b>\ for\ over\ a\ decade,\ mIRC\ has\ evolved\ into\ a\ powerful,\ reliable\ and\ fun\ piece\ of\ technology.<br></p>=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dr. Langeskov, The Tiger, and The Terribly Cursed Emerald: A Whirlwind Heist/application.js:2
-!A\ 15\ minute\ heist\ game\ by\ Crows\ Crows\ Crows\ &\ Directed\ by\ William\ Pugh\ (The\ Stanley\ Parable).\ =
+A\ 15\ minute\ heist\ game\ by\ Crows\ Crows\ Crows\ &\ Directed\ by\ William\ Pugh\ (The\ Stanley\ Parable).\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/CONSORTIUM/application.js:2
-!A\ murder\ mystery,\ on\ a\ plane,\ in\ the\ future.\ You\ are\ Consortium\ Bishop\ Six,\ a\ global\ peacekeeper\ in\ the\ year\ 2042.\ Your\ actions\ define\ and\ inform\ the\ ongoing\ narrative.=
+A\ murder\ mystery,\ on\ a\ plane,\ in\ the\ future.\ You\ are\ Consortium\ Bishop\ Six,\ a\ global\ peacekeeper\ in\ the\ year\ 2042.\ Your\ actions\ define\ and\ inform\ the\ ongoing\ narrative.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Room/application.js:2
-!A\ mysterious\ invitation\ leads\ to\ the\ attic\ of\ an\ abandoned\ house.\ In\ the\ room\ is\ a\ cast-iron\ safe\ laced\ with\ strange\ carvings\ and\ on\ top,\ a\ note\ from\ your\ distant\ companion.\ It\ promises\ something\ ancient\ and\ astonishing\ concealed\ in\ the\ iron\ chamber\ -\ you\ need\ only\ find\ a\ way\ in.=
+A\ mysterious\ invitation\ leads\ to\ the\ attic\ of\ an\ abandoned\ house.\ In\ the\ room\ is\ a\ cast-iron\ safe\ laced\ with\ strange\ carvings\ and\ on\ top,\ a\ note\ from\ your\ distant\ companion.\ It\ promises\ something\ ancient\ and\ astonishing\ concealed\ in\ the\ iron\ chamber\ -\ you\ need\ only\ find\ a\ way\ in.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Consortium: The Tower/application.js:2
-!A\ pure\ sci-fi\ single-player\ immersive\ simulation.\ Dive\ into\ a\ world\ shaped\ by\ YOUR\ choices\!\ Explore,\ talk,\ fight\ or\ sneak\ through\ The\ Churchill\ Tower\ in\ 2042\!\ Can\ you\ survive\ The\ Tower?=
+A\ pure\ sci-fi\ single-player\ immersive\ simulation.\ Dive\ into\ a\ world\ shaped\ by\ YOUR\ choices\!\ Explore,\ talk,\ fight\ or\ sneak\ through\ The\ Churchill\ Tower\ in\ 2042\!\ Can\ you\ survive\ The\ Tower?=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry/application.js:2
-!A\ tropical\ paradise\ seethes\ with\ hidden\ evil\ in\ Far\ Cry\u00ae,\ a\ cunningly\ detailed\ action\ shooter\ that\ pushes\ the\ boundaries\ of\ combat\ to\ shocking\ new\ levels.<br><br>Freelance\ mariner\ Jack\ Carver\ is\ cursing\ the\ day\ he\ ever\ came\ to\ this\ island.\ A\ week\ ago,\ a\ brash\ female\ reporter\ named\ Valerie\ had\ offered\ him\ an\ incredible\ sum\ of\ cash\ to\ take\ her\ to\ this\ unspoiled\ paradise.\ Shortly\ after\ docking,\ however,\ Jack's\ boat\ was\ greeted\ by\ artillery\ fire\ from\ a\ mysterious\ militia\ group\ swarming\ about\ the\ island.<br><br>With\ his\ boat\ destroyed,\ his\ money\ gone,\ and\ the\ gorgeous\ Valerie\ suddenly\ missing,\ Jack\ now\ finds\ himself\ facing\ an\ army\ of\ mercenaries\ amidst\ the\ wilds\ of\ the\ island,\ with\ nothing\ but\ a\ gun\ and\ his\ wits\ to\ survive.\ But\ the\ further\ he\ pushes\ into\ the\ lush\ jungle\ canopy,\ the\ stranger\ things\ become.<br><br>Jack\ encounters\ an\ insider\ within\ the\ militia\ group\ who\ reveals\ the\ horrific\ details\ of\ the\ mercenaries'\ true\ intentions.\ He\ presents\ Jack\ with\ an\ unsettling\ choice\:\ battle\ the\ deadliest\ mercenaries,\ or\ condemn\ the\ human\ race\ to\ a\ maniac's\ insidious\ agenda.=
+A\ tropical\ paradise\ seethes\ with\ hidden\ evil\ in\ Far\ Cry\u00ae,\ a\ cunningly\ detailed\ action\ shooter\ that\ pushes\ the\ boundaries\ of\ combat\ to\ shocking\ new\ levels.<br><br>Freelance\ mariner\ Jack\ Carver\ is\ cursing\ the\ day\ he\ ever\ came\ to\ this\ island.\ A\ week\ ago,\ a\ brash\ female\ reporter\ named\ Valerie\ had\ offered\ him\ an\ incredible\ sum\ of\ cash\ to\ take\ her\ to\ this\ unspoiled\ paradise.\ Shortly\ after\ docking,\ however,\ Jack's\ boat\ was\ greeted\ by\ artillery\ fire\ from\ a\ mysterious\ militia\ group\ swarming\ about\ the\ island.<br><br>With\ his\ boat\ destroyed,\ his\ money\ gone,\ and\ the\ gorgeous\ Valerie\ suddenly\ missing,\ Jack\ now\ finds\ himself\ facing\ an\ army\ of\ mercenaries\ amidst\ the\ wilds\ of\ the\ island,\ with\ nothing\ but\ a\ gun\ and\ his\ wits\ to\ survive.\ But\ the\ further\ he\ pushes\ into\ the\ lush\ jungle\ canopy,\ the\ stranger\ things\ become.<br><br>Jack\ encounters\ an\ insider\ within\ the\ militia\ group\ who\ reveals\ the\ horrific\ details\ of\ the\ mercenaries'\ true\ intentions.\ He\ presents\ Jack\ with\ an\ unsettling\ choice\:\ battle\ the\ deadliest\ mercenaries,\ or\ condemn\ the\ human\ race\ to\ a\ maniac's\ insidious\ agenda.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/category.js:1
-!Accessories=
+Accessories=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Adobe Acrobat Reader DC/application.js:1
-!Adobe\ Acrobat\ Reader\ DC=
+Adobe\ Acrobat\ Reader\ DC=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Adobe Acrobat Reader DC/application.js:2
-!Adobe\ Acrobat\ Reader\ DC\ software\ is\ the\ free\ global\ standard\ for\ reliably\ viewing,\ printing,\ and\ commenting\ on\ PDF\ documents.<br><br>Premium\ features,\ online\ services\ and\ updates\ do\ not\ work.=
+Adobe\ Acrobat\ Reader\ DC\ software\ is\ the\ free\ global\ standard\ for\ reliably\ viewing,\ printing,\ and\ commenting\ on\ PDF\ documents.<br><br>Premium\ features,\ online\ services\ and\ updates\ do\ not\ work.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Age of Empires II HD/application.js:1
-!Age\ of\ Empires\ II\ HD=
+Age\ of\ Empires\ II\ HD=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Age of Empires II HD/application.js:2
-!Age\ of\ Empires\ II\ has\ been\ re-imagined\ in\ high\ definition\ with\ new\ features,\ trading\ cards,\ improved\ AI,\ workshop\ support,\ multiplayer,\ Steamworks\ integration\ and\ more\!=
+Age\ of\ Empires\ II\ has\ been\ re-imagined\ in\ high\ definition\ with\ new\ features,\ trading\ cards,\ improved\ AI,\ workshop\ support,\ multiplayer,\ Steamworks\ integration\ and\ more\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Age of Empires III: Complete Collection/application.js:1
-!Age\ of\ Empires\u00ae\ III\:\ Complete\ Collection=
+Age\ of\ Empires\u00ae\ III\:\ Complete\ Collection=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prince of Persia: The Sands of Time/application.js:2
-!Amidst\ the\ scorched\ sands\ of\ ancient\ Persia,\ there\ is\ a\ legend\ spun\ in\ an\ ancient\ tongue.\ It\ speaks\ of\ a\ time\ borne\ by\ blood\ and\ ruled\ by\ deceit.\ Drawn\ to\ the\ dark\ powers\ of\ a\ magic\ dagger,\ a\ young\ Prince\ is\ led\ to\ unleash\ a\ deadly\ evil\ upon\ a\ beautiful\ kingdom.=
+Amidst\ the\ scorched\ sands\ of\ ancient\ Persia,\ there\ is\ a\ legend\ spun\ in\ an\ ancient\ tongue.\ It\ speaks\ of\ a\ time\ borne\ by\ blood\ and\ ruled\ by\ deceit.\ Drawn\ to\ the\ dark\ powers\ of\ a\ magic\ dagger,\ a\ young\ Prince\ is\ led\ to\ unleash\ a\ deadly\ evil\ upon\ a\ beautiful\ kingdom.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed II/application.js:2
-!An\ epic\ story\ of\ family,\ vengeance\ and\ conspiracy\ set\ in\ the\ pristine,\ yet\ brutal,\ backdrop\ of\ a\ Renaissance\ Italy.=
+An\ epic\ story\ of\ family,\ vengeance\ and\ conspiracy\ set\ in\ the\ pristine,\ yet\ brutal,\ backdrop\ of\ a\ Renaissance\ Italy.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Apps/Resources/script.js:1
-!App\ Resources=
+App\ Resources=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Apps/application.js:1
-!App\ Utils=
+App\ Utils=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mass Effect/application.js:2
-!As\ Commander\ Shepard,\ you\ lead\ an\ elite\ squad\ on\ a\ heroic,\ action-packed\ adventure\ throughout\ the\ galaxy.\ Discover\ the\ imminent\ danger\ from\ an\ ancient\ threat\ and\ battle\ the\ traitorous\ Saren\ and\ his\ deadly\ army\ to\ save\ civilization.\ The\ fate\ of\ all\ life\ depends\ on\ your\ actions\!=
+As\ Commander\ Shepard,\ you\ lead\ an\ elite\ squad\ on\ a\ heroic,\ action-packed\ adventure\ throughout\ the\ galaxy.\ Discover\ the\ imminent\ danger\ from\ an\ ancient\ threat\ and\ battle\ the\ traitorous\ Saren\ and\ his\ deadly\ army\ to\ save\ civilization.\ The\ fate\ of\ all\ life\ depends\ on\ your\ actions\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed Revelations/application.js:1
-!Assassin's\ Creed\u00ae\ Revelations=
+Assassin's\ Creed\u00ae\ Revelations=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed/application.js:1
-!Assassin's\ Creed\u2122=
+Assassin's\ Creed\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed/application.js:2
-!Assassin's\ Creed\u2122\ is\ the\ next-gen\ game\ developed\ by\ Ubisoft\ Montreal\ that\ redefines\ the\ action\ genre.\ While\ other\ games\ claim\ to\ be\ next-gen\ with\ impressive\ graphics\ and\ physics,\ Assassin's\ Creed\ merges\ technology,\ game\ design,\ theme\ and\ emotions\ into\ a\ world\ where\ you\ instigate\ chaos\ and\ become\ a\ vulnerable,\ yet\ powerful,\ agent\ of\ change.<br><br>The\ setting\ is\ 1191\ AD.\ The\ Third\ Crusade\ is\ tearing\ the\ Holy\ Land\ apart.\ You,\ Altair,\ intend\ to\ stop\ the\ hostilities\ by\ suppressing\ both\ sides\ of\ the\ conflict.You\ are\ an\ Assassin,\ a\ warrior\ shrouded\ in\ secrecy\ and\ feared\ for\ your\ ruthlessness.\ Your\ actions\ can\ throw\ your\ immediate\ environment\ into\ chaos,\ and\ your\ existence\ will\ shape\ events\ during\ this\ pivotal\ moment\ in\ history.=
+Assassin's\ Creed\u2122\ is\ the\ next-gen\ game\ developed\ by\ Ubisoft\ Montreal\ that\ redefines\ the\ action\ genre.\ While\ other\ games\ claim\ to\ be\ next-gen\ with\ impressive\ graphics\ and\ physics,\ Assassin's\ Creed\ merges\ technology,\ game\ design,\ theme\ and\ emotions\ into\ a\ world\ where\ you\ instigate\ chaos\ and\ become\ a\ vulnerable,\ yet\ powerful,\ agent\ of\ change.<br><br>The\ setting\ is\ 1191\ AD.\ The\ Third\ Crusade\ is\ tearing\ the\ Holy\ Land\ apart.\ You,\ Altair,\ intend\ to\ stop\ the\ hostilities\ by\ suppressing\ both\ sides\ of\ the\ conflict.You\ are\ an\ Assassin,\ a\ warrior\ shrouded\ in\ secrecy\ and\ feared\ for\ your\ ruthlessness.\ Your\ actions\ can\ throw\ your\ immediate\ environment\ into\ chaos,\ and\ your\ existence\ will\ shape\ events\ during\ this\ pivotal\ moment\ in\ history.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed II/application.js:1
-!Assassin\u2019s\ Creed\ II=
+Assassin\u2019s\ Creed\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed: Brotherhood/application.js:1
-!Assassin\u2019s\ Creed\u00ae\ Brotherhood=
+Assassin\u2019s\ Creed\u00ae\ Brotherhood=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed III/application.js:1
-!Assassin\u2019s\ Creed\u00ae\ III=
+Assassin\u2019s\ Creed\u00ae\ III=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed IV Black Flag/application.js:1
-!Assassin\u2019s\ Creed\u00ae\ IV\ Black\ Flag\u2122=
+Assassin\u2019s\ Creed\u00ae\ IV\ Black\ Flag\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed Unity/application.js:1
-!Assassin\u2019s\ Creed\u00ae\ Unity=
+Assassin\u2019s\ Creed\u00ae\ Unity=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed Unity/application.js:2
-!Assassin\u2019s\ Creed\u00ae\ Unity\ tells\ the\ story\ of\ Arno,\ a\ young\ man\ who\ embarks\ upon\ an\ extraordinary\ journey\ to\ expose\ the\ true\ powers\ behind\ the\ French\ Revolution.\ In\ the\ brand\ new\ co-op\ mode,\ you\ and\ your\ friends\ will\ also\ be\ thrown\ in\ the\ middle\ of\ a\ ruthless\ struggle\ for\ the\ fate\ of\ a\ nation.=
+Assassin\u2019s\ Creed\u00ae\ Unity\ tells\ the\ story\ of\ Arno,\ a\ young\ man\ who\ embarks\ upon\ an\ extraordinary\ journey\ to\ expose\ the\ true\ powers\ behind\ the\ French\ Revolution.\ In\ the\ brand\ new\ co-op\ mode,\ you\ and\ your\ friends\ will\ also\ be\ thrown\ in\ the\ middle\ of\ a\ ruthless\ struggle\ for\ the\ fate\ of\ a\ nation.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Audiosurf/application.js:1
-!Audiosurf=
+Audiosurf=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BRINK/application.js:1
-!BRINK=
+BRINK=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham City/application.js:2
-!Batman\:\ Arkham\ City\ builds\ upon\ the\ intense,\ atmospheric\ foundation\ of\ Batman\:\ Arkham\ Asylum,\ sending\ players\ flying\ through\ the\ expansive\ Arkham\ City\ -\ five\ times\ larger\ than\ the\ game\ world\ in\ Batman\:\ Arkham\ Asylum\ -\ the\ new\ maximum\ security\ =
+Batman\:\ Arkham\ City\ builds\ upon\ the\ intense,\ atmospheric\ foundation\ of\ Batman\:\ Arkham\ Asylum,\ sending\ players\ flying\ through\ the\ expansive\ Arkham\ City\ -\ five\ times\ larger\ than\ the\ game\ world\ in\ Batman\:\ Arkham\ Asylum\ -\ the\ new\ maximum\ security\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham Asylum/application.js:1
-!Batman\u2122\:\ Arkham\ Asylum=
+Batman\u2122\:\ Arkham\ Asylum=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham City/application.js:1
-!Batman\u2122\:\ Arkham\ City=
+Batman\u2122\:\ Arkham\ City=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham Origins/application.js:1
-!Batman\u2122\:\ Arkham\ Origins=
+Batman\u2122\:\ Arkham\ Origins=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham Origins/application.js:2
-!Batman\u2122\:\ Arkham\ Origins\ is\ the\ next\ installment\ in\ the\ blockbuster\ Batman\:\ Arkham\ videogame\ franchise.\ Developed\ by\ WB\ Games\ Montr\u00e9al,\ the\ game\ features\ an\ expanded\ Gotham\ City\ and\ introduces\ an\ original\ prequel\ storyline\ set\ several\ years\ before\ the\ events\ of\ Batman\:\ Arkham\ Asylum\ and\ Batman\:\ Arkham\ City,\ the\ first\ two\ critically\ acclaimed\ games\ of\ the\ franchise.\ Taking\ place\ before\ the\ rise\ of\ Gotham\ City\u2019s\ most\ dangerous\ criminals,\ the\ game\ showcases\ a\ young\ and\ unrefined\ Batman\ as\ he\ faces\ a\ defining\ moment\ in\ his\ early\ career\ as\ a\ crime\ fighter\ that\ sets\ his\ path\ to\ becoming\ the\ Dark\ Knight.=
+Batman\u2122\:\ Arkham\ Origins\ is\ the\ next\ installment\ in\ the\ blockbuster\ Batman\:\ Arkham\ videogame\ franchise.\ Developed\ by\ WB\ Games\ Montr\u00e9al,\ the\ game\ features\ an\ expanded\ Gotham\ City\ and\ introduces\ an\ original\ prequel\ storyline\ set\ several\ years\ before\ the\ events\ of\ Batman\:\ Arkham\ Asylum\ and\ Batman\:\ Arkham\ City,\ the\ first\ two\ critically\ acclaimed\ games\ of\ the\ franchise.\ Taking\ place\ before\ the\ rise\ of\ Gotham\ City\u2019s\ most\ dangerous\ criminals,\ the\ game\ showcases\ a\ young\ and\ unrefined\ Batman\ as\ he\ faces\ a\ defining\ moment\ in\ his\ early\ career\ as\ a\ crime\ fighter\ that\ sets\ his\ path\ to\ becoming\ the\ Dark\ Knight.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Wildlife Park 2/application.js:2
-!Become\ a\ zoo\ manager\ and\ take\ good\ care\ of\ your\ animals.\ Wildlife\ Park\ 2\ brings\ you\ into\ up\ close\ and\ personal\ contact\ with\ more\ than\ 50\ different\ animal\ species.\ Observe\ the\ lovingly\ animated\ interaction\ of\ the\ animals\ -\ with\ other\ animals,\ the\ landscape,\ the\ play\ equipment,\ or\ the\ visitors\ to\ the\ park\!\ Just\ like\ in\ a\ real\ zoo,\ the\ animals\ must\ receive\ all-round\ care.\ This\ is\ as\ easy\ as\ winking\ in\ Wildlife\ Park\ 2\:\ With\ a\ click\ of\ the\ mouse\ you\ can\ feed,\ doctor,\ pet,\ or\ even\ relocate\ animals,\ or\ get\ them\ moving.\ You\ will\ guide\ a\ team\ of\ landscape\ architects,\ gardeners,\ keepers,\ veterinarians,\ and\ scientists.\ If\ you\ manage\ your\ zoo\ carefully,\ you\ will\ soon\ be\ able\ to\ celebrate\ the\ birth\ of\ new\ animals\!\ Construct\ your\ zoo\ using\ more\ than\ 100\ animal\ houses,\ visitor\ facilities,\ staff\ buildings,\ decorative\ park\ elements,\ and\ enclosure\ equipment.\ Wildlife\ Park\ 2\ is\ an\ ideal\ playground\ for\ amateur\ architects,\ too\!\ Use\ the\ extensive\ terraforming\ options\ to\ create\ your\ own\ imaginative\ landscapes.\ Plenty\ of\ established\ plant\ species\ and\ botanical\ rarities\ such\ us\ underwater\ plants\ or\ cacti\ will\ thrive\ under\ your\ loving\ care,\ and\ all\ this\ is\ lavishly\ displayed\ by\ a\ dynamic\ plant\ system.\ Another\ specialty\ is\ the\ realistically\ simulated\ flow\ of\ water.\ By\ easily\ placing\ a\ water\ source,\ you\ can\ create\ thunderous\ waterfalls\ and\ rambling\ water\ worlds.\ Visitors\ to\ your\ zoo\ will\ expect\ a\ few\ treats,\ too\ -\ build\ restaurants\ and\ ice-cream\ parlors\ and\ provide\ spectacular\ entertainment.\ Employ\ advertising\ and\ marketing\ to\ attract\ new\ visitors.\ But\ don't\ forget\ to\ keep\ an\ eye\ on\ your\ zoo's\ budget\ at\ all\ times\!=
+Become\ a\ zoo\ manager\ and\ take\ good\ care\ of\ your\ animals.\ Wildlife\ Park\ 2\ brings\ you\ into\ up\ close\ and\ personal\ contact\ with\ more\ than\ 50\ different\ animal\ species.\ Observe\ the\ lovingly\ animated\ interaction\ of\ the\ animals\ -\ with\ other\ animals,\ the\ landscape,\ the\ play\ equipment,\ or\ the\ visitors\ to\ the\ park\!\ Just\ like\ in\ a\ real\ zoo,\ the\ animals\ must\ receive\ all-round\ care.\ This\ is\ as\ easy\ as\ winking\ in\ Wildlife\ Park\ 2\:\ With\ a\ click\ of\ the\ mouse\ you\ can\ feed,\ doctor,\ pet,\ or\ even\ relocate\ animals,\ or\ get\ them\ moving.\ You\ will\ guide\ a\ team\ of\ landscape\ architects,\ gardeners,\ keepers,\ veterinarians,\ and\ scientists.\ If\ you\ manage\ your\ zoo\ carefully,\ you\ will\ soon\ be\ able\ to\ celebrate\ the\ birth\ of\ new\ animals\!\ Construct\ your\ zoo\ using\ more\ than\ 100\ animal\ houses,\ visitor\ facilities,\ staff\ buildings,\ decorative\ park\ elements,\ and\ enclosure\ equipment.\ Wildlife\ Park\ 2\ is\ an\ ideal\ playground\ for\ amateur\ architects,\ too\!\ Use\ the\ extensive\ terraforming\ options\ to\ create\ your\ own\ imaginative\ landscapes.\ Plenty\ of\ established\ plant\ species\ and\ botanical\ rarities\ such\ us\ underwater\ plants\ or\ cacti\ will\ thrive\ under\ your\ loving\ care,\ and\ all\ this\ is\ lavishly\ displayed\ by\ a\ dynamic\ plant\ system.\ Another\ specialty\ is\ the\ realistically\ simulated\ flow\ of\ water.\ By\ easily\ placing\ a\ water\ source,\ you\ can\ create\ thunderous\ waterfalls\ and\ rambling\ water\ worlds.\ Visitors\ to\ your\ zoo\ will\ expect\ a\ few\ treats,\ too\ -\ build\ restaurants\ and\ ice-cream\ parlors\ and\ provide\ spectacular\ entertainment.\ Employ\ advertising\ and\ marketing\ to\ attract\ new\ visitors.\ But\ don't\ forget\ to\ keep\ an\ eye\ on\ your\ zoo's\ budget\ at\ all\ times\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS: Dark Forces/application.js:2
-!Behind\ a\ veil\ of\ secrecy\ the\ evil\ Empire\ is\ creating\ a\ doomsday\ army\ -\ one\ that,\ if\ finished,\ will\ become\ the\ final\ cog\ in\ the\ Empire's\ arsenal\ of\ terror\ and\ domination.\ Your\ Mission?\ Join\ the\ Rebel\ Alliance's\ covert\ operations\ division,\ infiltrate\ the\ Empire.=
+Behind\ a\ veil\ of\ secrecy\ the\ evil\ Empire\ is\ creating\ a\ doomsday\ army\ -\ one\ that,\ if\ finished,\ will\ become\ the\ final\ cog\ in\ the\ Empire's\ arsenal\ of\ terror\ and\ domination.\ Your\ Mission?\ Join\ the\ Rebel\ Alliance's\ covert\ operations\ division,\ infiltrate\ the\ Empire.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Beyond Good and Evil/application.js:1
-!Beyond\ Good\ and\ Evil\u2122=
+Beyond\ Good\ and\ Evil\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Orwell: Keeping an Eye On You/application.js:2
-!Big\ Brother\ has\ arrived\ -\ and\ it\u2019s\ you.\ Investigate\ the\ lives\ of\ citizens\ to\ find\ those\ responsible\ for\ a\ series\ of\ terror\ attacks.\ Information\ from\ the\ internet,\ personal\ communications\ and\ private\ files\ are\ all\ accessible\ to\ you.\ But,\ be\ warned,\ the\ information\ you\ supply\ will\ have\ consequences.=
+Big\ Brother\ has\ arrived\ -\ and\ it\u2019s\ you.\ Investigate\ the\ lives\ of\ citizens\ to\ find\ those\ responsible\ for\ a\ series\ of\ terror\ attacks.\ Information\ from\ the\ internet,\ personal\ communications\ and\ private\ files\ are\ all\ accessible\ to\ you.\ But,\ be\ warned,\ the\ information\ you\ supply\ will\ have\ consequences.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BioShock/application.js:2
-!BioShock\ is\ a\ shooter\ unlike\ any\ you've\ ever\ played,\ loaded\ with\ weapons\ and\ tactics\ never\ seen.\ You'll\ have\ a\ complete\ arsenal\ at\ your\ disposal\ from\ simple\ revolvers\ to\ grenade\ launchers\ and\ chemical\ throwers,\ but\ you'll\ also\ be\ forced\ to\ genetically\ modify\ your\ DNA\ to\ create\ an\ even\ more\ deadly\ weapon\:\ you.\ Injectable\ plasmids\ give\ you\ super\ human\ powers\:\ blast\ electrical\ currents\ into\ water\ to\ electrocute\ multiple\ enemies,\ or\ freeze\ them\ solid\ and\ obliterate\ them\ with\ the\ swing\ of\ a\ wrench.<br>No\ encounter\ ever\ plays\ out\ the\ same,\ and\ no\ two\ gamers\ will\ play\ the\ game\ the\ same\ way.=
+BioShock\ is\ a\ shooter\ unlike\ any\ you've\ ever\ played,\ loaded\ with\ weapons\ and\ tactics\ never\ seen.\ You'll\ have\ a\ complete\ arsenal\ at\ your\ disposal\ from\ simple\ revolvers\ to\ grenade\ launchers\ and\ chemical\ throwers,\ but\ you'll\ also\ be\ forced\ to\ genetically\ modify\ your\ DNA\ to\ create\ an\ even\ more\ deadly\ weapon\:\ you.\ Injectable\ plasmids\ give\ you\ super\ human\ powers\:\ blast\ electrical\ currents\ into\ water\ to\ electrocute\ multiple\ enemies,\ or\ freeze\ them\ solid\ and\ obliterate\ them\ with\ the\ swing\ of\ a\ wrench.<br>No\ encounter\ ever\ plays\ out\ the\ same,\ and\ no\ two\ gamers\ will\ play\ the\ game\ the\ same\ way.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BioShock/application.js:1
-!BioShock\u2122=
+BioShock\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS: The Old Republic/application.js:2
-!BioWare\ and\ LucasArts\ bring\ you\ the\ next\ evolution\ in\ MMO\ Gameplay.\ Explore\ an\ age\ thousands\ of\ years\ before\ the\ rise\ of\ Darth\ Vader\ when\ war\ between\ the\ Galactic\ Republic\ and\ the\ Sith\ Empire\ divides\ the\ galaxy.=
+BioWare\ and\ LucasArts\ bring\ you\ the\ next\ evolution\ in\ MMO\ Gameplay.\ Explore\ an\ age\ thousands\ of\ years\ before\ the\ rise\ of\ Darth\ Vader\ when\ war\ between\ the\ Galactic\ Republic\ and\ the\ Sith\ Empire\ divides\ the\ galaxy.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's The Division/application.js:2
-!Black\ Friday\ \u2013\ a\ devastating\ pandemic\ sweeps\ through\ New\ York\ City,\ and\ one\ by\ one,\ basic\ services\ fail.\ In\ only\ days,\ without\ food\ or\ water,\ society\ collapses\ into\ chaos.\ The\ Division,\ an\ autonomous\ unit\ of\ tactical\ agents,\ is\ activated.=
+Black\ Friday\ \u2013\ a\ devastating\ pandemic\ sweeps\ through\ New\ York\ City,\ and\ one\ by\ one,\ basic\ services\ fail.\ In\ only\ days,\ without\ food\ or\ water,\ society\ collapses\ into\ chaos.\ The\ Division,\ an\ autonomous\ unit\ of\ tactical\ agents,\ is\ activated.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Black Mesa/application.js:1
-!Black\ Mesa=
+Black\ Mesa=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Blizzard app/application.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Blizzard app/Online/script.js:1
-!Blizzard\ app=
+Blizzard\ app=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Borderlands/application.js:1
-!Borderlands=
+Borderlands=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Braid/application.js:1
-!Braid=
+Braid=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Braid/application.js:2
-!Braid\ is\ a\ puzzle-platformer,\ drawn\ in\ a\ painterly\ style,\ where\ you\ can\ manipulate\ the\ flow\ of\ time\ in\ strange\ and\ unusual\ ways.\ From\ a\ house\ in\ the\ city,\ journey\ to\ a\ series\ of\ worlds\ and\ solve\ puzzles\ to\ rescue\ an\ abducted\ princess.=
+Braid\ is\ a\ puzzle-platformer,\ drawn\ in\ a\ painterly\ style,\ where\ you\ can\ manipulate\ the\ flow\ of\ time\ in\ strange\ and\ unusual\ ways.\ From\ a\ house\ in\ the\ city,\ journey\ to\ a\ series\ of\ worlds\ and\ solve\ puzzles\ to\ rescue\ an\ abducted\ princess.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Burnout Paradise: The Ultimate Box/application.js:1
-!Burnout\u2122\ Paradise\:\ The\ Ultimate\ Box=
+Burnout\u2122\ Paradise\:\ The\ Ultimate\ Box=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/CONSORTIUM/application.js:1
-!CONSORTIUM=
+CONSORTIUM=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Caesar III/application.js:1
-!Caesar\ III=
+Caesar\ III=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Call of Juarez Gunslinger/application.js:1
-!Call\ of\ Juarez\u00ae\ Gunslinger=
+Call\ of\ Juarez\u00ae\ Gunslinger=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mount & Blade/application.js:2
-!Calradia\ is\ a\ land\ at\ war,\ offering\ great\ riches\ and\ even\ greater\ dangers\ to\ adventurers\ and\ mercenaries\ that\ flock\ to\ shed\ their\ blood\ on\ its\ soil.\ With\ courage\ and\ a\ strong\ sword,\ an\ unknown\ stranger\ can\ make\ a\ name\ as\ a\ warrior.=
+Calradia\ is\ a\ land\ at\ war,\ offering\ great\ riches\ and\ even\ greater\ dangers\ to\ adventurers\ and\ mercenaries\ that\ flock\ to\ shed\ their\ blood\ on\ its\ soil.\ With\ courage\ and\ a\ strong\ sword,\ an\ unknown\ stranger\ can\ make\ a\ name\ as\ a\ warrior.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:215
-!Cannot\ run\ 64bit\ executable\ in\ a\ 32bit\ Wine\ prefix.=
+Cannot\ run\ 64bit\ executable\ in\ a\ 32bit\ Wine\ prefix.=
 
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Filesystem/Files/script.js:154
-!Checking\ file\ consistency\ ...=
+Checking\ file\ consistency\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/ChromaGun/application.js:1
-!ChromaGun=
+ChromaGun=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Civilization V/application.js:1
-!Civilization\ V=
+Civilization\ V=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Clicker Heroes/application.js:1
-!Clicker\ Heroes=
+Clicker\ Heroes=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Cogs/application.js:1
-!Cogs=
+Cogs=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Cogs/application.js:2
-!Cogs\ is\ a\ puzzle\ game\ where\ players\ build\ machines\ from\ sliding\ tiles.\ Players\ can\ choose\ from\ 50\ levels\ and\ 3\ gameplay\ modes.\ New\ puzzles\ are\ unlocked\ by\ building\ contraptions\ quickly\ and\ efficiently.=
+Cogs\ is\ a\ puzzle\ game\ where\ players\ build\ machines\ from\ sliding\ tiles.\ Players\ can\ choose\ from\ 50\ levels\ and\ 3\ gameplay\ modes.\ New\ puzzles\ are\ unlocked\ by\ building\ contraptions\ quickly\ and\ efficiently.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Command and Conquer - Tiberium Wars/application.js:1
-!Command\ and\ Conquer\ -\ Tiberium\ Wars=
+Command\ and\ Conquer\ -\ Tiberium\ Wars=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS - Empire at War - Gold Pack/application.js:2
-!Command\ or\ corrupt\ an\ entire\ galaxy\ in\ the\ definitive\ Star\ Wars\ strategy\ collection.\ It\ is\ a\ time\ of\ galactic\ civil\ war.\ Will\ you\ take\ up\ the\ reins\ of\ the\ Rebellion,\ assume\ control\ of\ the\ Empire,\ or\ rule\ the\ Star\ Wars\ Underworld?=
+Command\ or\ corrupt\ an\ entire\ galaxy\ in\ the\ definitive\ Star\ Wars\ strategy\ collection.\ It\ is\ a\ time\ of\ galactic\ civil\ war.\ Will\ you\ take\ up\ the\ reins\ of\ the\ Rebellion,\ assume\ control\ of\ the\ Empire,\ or\ rule\ the\ Star\ Wars\ Underworld?=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/WineConsole/script.js:1
-!Command\ prompt=
+Command\ prompt=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Configure Wine/script.js:1
-!Configure\ Wine=
+Configure\ Wine=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Consortium: The Tower/application.js:1
-!Consortium\:\ The\ Tower=
+Consortium\:\ The\ Tower=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:888
-!Could\ not\ determine\ mimetype\ for\ file\ extension\ "{0}"=
+Could\ not\ determine\ mimetype\ for\ file\ extension\ "{0}"=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:276
-!Could\ not\ uninstall\ {0}\!=
+Could\ not\ uninstall\ {0}\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Crayon Physics/application.js:1
-!Crayon\ Physics=
+Crayon\ Physics=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Crayon Physics/application.js:2
-!Crayon\ Physics\ is\ a\ mouse\ arcade\ game.\ You\ will\ have\ to\ draw\ lines\ and\ squares\ to\ move\ a\ ball.\ The\ aim\ is\ to\ catch\ the\ stars\ in\ the\ level.\ =
+Crayon\ Physics\ is\ a\ mouse\ arcade\ game.\ You\ will\ have\ to\ draw\ lines\ and\ squares\ to\ move\ a\ ball.\ The\ aim\ is\ to\ catch\ the\ stars\ in\ the\ level.\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/category.js:1
-!Custom=
+Custom=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Custom Installer Script/script.js:1
-!Custom\ Installer\ Script=
+Custom\ Installer\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/DC Universe Online/application.js:1
-!DC\ Universe\ Online=
+DC\ Universe\ Online=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/DOOM (2016)/application.js:1
-!DOOM\ (2016)=
+DOOM\ (2016)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dragon Ball Xenoverse 2/application.js:2
-!DRAGON\ BALL\ XENOVERSE\ 2\ builds\ upon\ the\ highly\ popular\ DRAGON\ BALL\ XENOVERSE\ with\ enhanced\ graphics\ that\ will\ further\ immerse\ players\ into\ the\ largest\ and\ most\ detailed\ Dragon\ Ball\ world\ ever\ developed.<br><br>DRAGON\ BALL\ XENOVERSE\ 2\ will\ deliver\ a\ new\ hub\ city\ and\ the\ most\ character\ customization\ choices\ to\ date\ among\ a\ multitude\ of\ new\ features\ and\ special\ upgrades.=
+DRAGON\ BALL\ XENOVERSE\ 2\ builds\ upon\ the\ highly\ popular\ DRAGON\ BALL\ XENOVERSE\ with\ enhanced\ graphics\ that\ will\ further\ immerse\ players\ into\ the\ largest\ and\ most\ detailed\ Dragon\ Ball\ world\ ever\ developed.<br><br>DRAGON\ BALL\ XENOVERSE\ 2\ will\ deliver\ a\ new\ hub\ city\ and\ the\ most\ character\ customization\ choices\ to\ date\ among\ a\ multitude\ of\ new\ features\ and\ special\ upgrades.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/DXVK/script.js:1
-!DXVK=
+DXVK=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/DOOM (2016)/application.js:2
-!Developed\ by\ id\ software,\ the\ studio\ that\ pioneered\ the\ first-person\ shooter\ genre\ and\ created\ multiplayer\ Deathmatch,\ DOOM\ returns\ as\ a\ brutally\ fun\ and\ challenging\ modern-day\ shooter\ experience.\ Relentless\ demons,\ impossibly\ destructive\ guns,\ and\ fast,\ fluid\ movement\ provide\ the\ foundation\ for\ intense,\ first-person\ combat\ \u2013\ whether\ you\u2019re\ obliterating\ demon\ hordes\ through\ the\ depths\ of\ Hell\ in\ the\ single-player\ campaign,\ or\ competing\ against\ your\ friends\ in\ numerous\ multiplayer\ modes.\ Expand\ your\ gameplay\ experience\ using\ DOOM\ SnapMap\ game\ editor\ to\ easily\ create,\ play,\ and\ share\ your\ content\ with\ the\ world.=
+Developed\ by\ id\ software,\ the\ studio\ that\ pioneered\ the\ first-person\ shooter\ genre\ and\ created\ multiplayer\ Deathmatch,\ DOOM\ returns\ as\ a\ brutally\ fun\ and\ challenging\ modern-day\ shooter\ experience.\ Relentless\ demons,\ impossibly\ destructive\ guns,\ and\ fast,\ fluid\ movement\ provide\ the\ foundation\ for\ intense,\ first-person\ combat\ \u2013\ whether\ you\u2019re\ obliterating\ demon\ hordes\ through\ the\ depths\ of\ Hell\ in\ the\ single-player\ campaign,\ or\ competing\ against\ your\ friends\ in\ numerous\ multiplayer\ modes.\ Expand\ your\ gameplay\ experience\ using\ DOOM\ SnapMap\ game\ editor\ to\ easily\ create,\ play,\ and\ share\ your\ content\ with\ the\ world.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Development/category.js:1
-!Development=
+Development=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Net/Download/script.js:1
-!Downloader=
+Downloader=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dr. Langeskov, The Tiger, and The Terribly Cursed Emerald: A Whirlwind Heist/application.js:1
-!Dr.\ Langeskov,\ The\ Tiger,\ and\ The\ Terribly\ Cursed\ Emerald\:\ A\ Whirlwind\ Heist=
+Dr.\ Langeskov,\ The\ Tiger,\ and\ The\ Terribly\ Cursed\ Emerald\:\ A\ Whirlwind\ Heist=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dragon Ball Xenoverse/application.js:1
-!Dragon\ Ball\ Xenoverse=
+Dragon\ Ball\ Xenoverse=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dragon Ball Xenoverse 2/application.js:1
-!Dragon\ Ball\ Xenoverse\ 2=
+Dragon\ Ball\ Xenoverse\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Druid Soccer/application.js:1
-!Druid\ Soccer=
+Druid\ Soccer=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Earth Eternal - Valkal's Shadow/application.js:1
-!Earth\ Eternal\ -\ Valkal's\ Shadow=
+Earth\ Eternal\ -\ Valkal's\ Shadow=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Elite:Dangerous/application.js:1
-!Elite\:Dangerous=
+Elite\:Dangerous=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/ElsterFormular/application.js:1
-!ElsterFormular=
+ElsterFormular=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/ElsterFormular/application.js:2
-!ElsterFormular\ is\ the\ official\ german\ software\ to\ file\ a\ tax\ return.=
+ElsterFormular\ is\ the\ official\ german\ software\ to\ file\ a\ tax\ return.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Total War Rome II/application.js:2
-!Emperor\ Edition\ is\ the\ definitive\ edition\ of\ ROME\ II,\ featuring\ an\ improved\ politics\ system,\ overhauled\ building\ chains,\ rebalanced\ battles\ and\ improved\ visuals\ in\ both\ campaign\ and\ battle.<br><br>In\ addition,\ Emperor\ Edition\ includes\ all\ content\ and\ feature\ updates\ made\ available\ for\ ROME\ II\ since\ its\ launch\ in\ September\ 2013.\ These\ include\ Twitch.TV\ integration,\ touchscreen\ controls,\ new\ playable\ factions\ and\ units,\ and\ Mac\ compatibility.\ The\ Imperator\ Augustus\ Campaign\ Pack\ and\ all\ Emperor\ Edition\ content\ and\ features\ are\ free,\ via\ automatic\ update,\ to\ all\ existing\ ROME\ II\ owners.=
+Emperor\ Edition\ is\ the\ definitive\ edition\ of\ ROME\ II,\ featuring\ an\ improved\ politics\ system,\ overhauled\ building\ chains,\ rebalanced\ battles\ and\ improved\ visuals\ in\ both\ campaign\ and\ battle.<br><br>In\ addition,\ Emperor\ Edition\ includes\ all\ content\ and\ feature\ updates\ made\ available\ for\ ROME\ II\ since\ its\ launch\ in\ September\ 2013.\ These\ include\ Twitch.TV\ integration,\ touchscreen\ controls,\ new\ playable\ factions\ and\ units,\ and\ Mac\ compatibility.\ The\ Imperator\ Augustus\ Campaign\ Pack\ and\ all\ Emperor\ Edition\ content\ and\ features\ are\ free,\ via\ automatic\ update,\ to\ all\ existing\ ROME\ II\ owners.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Enderal/application.js:1
-!Enderal=
+Enderal=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Enderal/application.js:2
-!Enderal\ is\ a\ total\ conversion\ for\ TES\ V\:\ Skyrim\:\ a\ game\ modification\ that\ is\ set\ in\ its\ own\ world\ with\ its\ own\ landscape,\ lore\ and\ story.\ It\ offers\ an\ immersive\ open\ world,\ all\ for\ the\ player\ to\ explore,\ overhauled\ skill\ systems\ and\ gameplay\ mechanics\ and\ a\ dark,\ psychological\ storyline\ with\ believable\ characters.=
+Enderal\ is\ a\ total\ conversion\ for\ TES\ V\:\ Skyrim\:\ a\ game\ modification\ that\ is\ set\ in\ its\ own\ world\ with\ its\ own\ landscape,\ lore\ and\ story.\ It\ offers\ an\ immersive\ open\ world,\ all\ for\ the\ player\ to\ explore,\ overhauled\ skill\ systems\ and\ gameplay\ mechanics\ and\ a\ dark,\ psychological\ storyline\ with\ believable\ characters.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tropico 3/application.js:2
-!Engage\ in\ a\ tropical\ power\ trip\!\ Become\ the\ dictator\ of\ a\ remote\ island\ during\ the\ Cold\ War.\ Charm,\ persuade,\ intimidate,\ oppress,\ or\ cheat\ your\ people\ to\ stay\ in\ power\!\ Are\ you\ a\ kind\ and\ generous\ leader?\ A\ corrupt\ and\ ruthless\ tyrant\ ruling\ with\ an\ iron\ fist?\ Turn\ your\ island\ into\ a\ tourist\ paradise\ or\ an\ industrial\ power.\ Make\ promises\ to\ the\ electorate\ or\ slander\ political\ adversaries\ to\ get\ the\ crucial\ votes\ for\ the\ upcoming\ elections.\ Send\ your\ avatar\ to\ congratulate\ the\ people,\ visit\ the\ island\ of\ another\ player,\ or\ just\ sun-bathe\ on\ the\ Caribbean\ beach.=
+Engage\ in\ a\ tropical\ power\ trip\!\ Become\ the\ dictator\ of\ a\ remote\ island\ during\ the\ Cold\ War.\ Charm,\ persuade,\ intimidate,\ oppress,\ or\ cheat\ your\ people\ to\ stay\ in\ power\!\ Are\ you\ a\ kind\ and\ generous\ leader?\ A\ corrupt\ and\ ruthless\ tyrant\ ruling\ with\ an\ iron\ fist?\ Turn\ your\ island\ into\ a\ tourist\ paradise\ or\ an\ industrial\ power.\ Make\ promises\ to\ the\ electorate\ or\ slander\ political\ adversaries\ to\ get\ the\ crucial\ votes\ for\ the\ upcoming\ elections.\ Send\ your\ avatar\ to\ congratulate\ the\ people,\ visit\ the\ island\ of\ another\ player,\ or\ just\ sun-bathe\ on\ the\ Caribbean\ beach.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Epic Games Launcher/application.js:1
-!Epic\ Games\ Launcher=
+Epic\ Games\ Launcher=
 
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Net/Download/script.js:126
-!Error\ while\ calculating\ checksum.\ \n\nExpected\ \=\ {0}\nActual\ \=\ {1}=
+Error\ while\ calculating\ checksum.\ \n\nExpected\ \=\ {0}\nActual\ \=\ {1}=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Ether One Redux/application.js:1
-!Ether\ One\ Redux=
+Ether\ One\ Redux=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Ether One Redux/application.js:2
-!Ether\ One\ is\ a\ first\ person\ adventure\ that\ deals\ with\ the\ fragility\ of\ the\ human\ mind.\ There\ are\ two\ paths\ in\ the\ world\ you\ can\ choose\ from.\ At\ its\ core\ is\ a\ story\ exploration\ path\ free\ from\ puzzles\ where\ you\ can\ unfold\ the\ story\ at\ your\ own\ pace.=
+Ether\ One\ is\ a\ first\ person\ adventure\ that\ deals\ with\ the\ fragility\ of\ the\ human\ mind.\ There\ are\ two\ paths\ in\ the\ world\ you\ can\ choose\ from.\ At\ its\ core\ is\ a\ story\ exploration\ path\ free\ from\ puzzles\ where\ you\ can\ unfold\ the\ story\ at\ your\ own\ pace.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis II/application.js:1
-!Europa\ Universalis\ II=
+Europa\ Universalis\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis II/application.js:2
-!Europa\ Universalis\ II\ is\ a\ strategy\ computer\ game\ developed\ by\ Paradox\ Development\ Studio\ and\ published\ by\ Strategy\ First,\ based\ on\ world\ history\ spanning\ a\ timeline\ between\ 1419\ through\ 1820.=
+Europa\ Universalis\ II\ is\ a\ strategy\ computer\ game\ developed\ by\ Paradox\ Development\ Studio\ and\ published\ by\ Strategy\ First,\ based\ on\ world\ history\ spanning\ a\ timeline\ between\ 1419\ through\ 1820.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis IV/application.js:1
-!Europa\ Universalis\ IV=
+Europa\ Universalis\ IV=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Clicker Heroes/application.js:2
-!Ever\ wondered\ what\ one\ quadrillion\ damage\ per\ second\ feels\ like?\ Wonder\ no\ more\!\ Embark\ on\ your\ quest\ to\ attain\ it\ today\!\ Start\ out\ by\ clicking\ on\ the\ monster\ to\ kill\ them,\ and\ get\ their\ gold.\ Spend\ that\ gold\ on\ hiring\ new\ heroes\ and\ get\ more\ damage.\ The\ more\ damage\ you\ deal,\ the\ more\ gold\ you\ will\ get.=
+Ever\ wondered\ what\ one\ quadrillion\ damage\ per\ second\ feels\ like?\ Wonder\ no\ more\!\ Embark\ on\ your\ quest\ to\ attain\ it\ today\!\ Start\ out\ by\ clicking\ on\ the\ monster\ to\ kill\ them,\ and\ get\ their\ gold.\ Spend\ that\ gold\ on\ hiring\ new\ heroes\ and\ get\ more\ damage.\ The\ more\ damage\ you\ deal,\ the\ more\ gold\ you\ will\ get.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Shortcuts/Wine/script.js:120
-!Executable\ {0}\ not\ found\!=
+Executable\ {0}\ not\ found\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rayman Origins/application.js:2
-!Experience\ the\ magical\ universe\ of\ Rayman\ with\ legendary\ 2D\ gameplay\ that\ has\ captured\ the\ hearts\ of\ millions\ of\ fans\!=
+Experience\ the\ magical\ universe\ of\ Rayman\ with\ legendary\ 2D\ gameplay\ that\ has\ captured\ the\ hearts\ of\ millions\ of\ fans\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Batman™: Arkham Asylum/application.js:2
-!Experience\ what\ it\u2019s\ like\ to\ be\ Batman\ and\ face\ off\ against\ Gotham's\ greatest\ villians.\ Explore\ every\ inch\ of\ Arkham\ Asylum\ and\ roam\ freely\ on\ the\ infamous\ island.<br><br>Critically\ acclaimed\ Batman\:\ Arkham\ Asylum\ returns\ with\ a\ remastered\ Game\ of\ the\ Year\ Edition,\ featuring\ 4\ extra\ Challenge\ Maps.\ The\ additional\ Challenge\ Maps\ are\ Crime\ Alley;\ Scarecrow\ Nightmare;\ Totally\ Insane\ and\ Nocturnal\ Hunter\ (both\ from\ the\ Insane\ Night\ Map\ Pack).=
+Experience\ what\ it\u2019s\ like\ to\ be\ Batman\ and\ face\ off\ against\ Gotham's\ greatest\ villians.\ Explore\ every\ inch\ of\ Arkham\ Asylum\ and\ roam\ freely\ on\ the\ infamous\ island.<br><br>Critically\ acclaimed\ Batman\:\ Arkham\ Asylum\ returns\ with\ a\ remastered\ Game\ of\ the\ Year\ Edition,\ featuring\ 4\ extra\ Challenge\ Maps.\ The\ additional\ Challenge\ Maps\ are\ Crime\ Alley;\ Scarecrow\ Nightmare;\ Totally\ Insane\ and\ Nocturnal\ Hunter\ (both\ from\ the\ Insane\ Night\ Map\ Pack).=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx10/script.js:14
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx10/script.js:15
@@ -340,200 +340,200 @@
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx9/script.js:14
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx9/script.js:15
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx9/script.js:35
-!Extracting\ {0}\ ...=
+Extracting\ {0}\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed Revelations/application.js:2
-!Ezio\ Auditore\ walks\ in\ the\ footsteps\ of\ the\ legendary\ mentor\ Altair,\ on\ a\ dangerous\ journey\ of\ discovery\ and\ revelation.=
+Ezio\ Auditore\ walks\ in\ the\ footsteps\ of\ the\ legendary\ mentor\ Altair,\ on\ a\ dangerous\ journey\ of\ discovery\ and\ revelation.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Dragon Ball Xenoverse/application.js:2
-!FOR\ THE\ FIRST\ TIME\ EVER,\ THE\ DRAGON\ BALL\ UNIVERSE\ IS\ COMING\ TO\ STEAM\!<br><br>DRAGON\ BALL\ XENOVERSE\ revisits\ famous\ battles\ from\ the\ series\ through\ your\ custom\ Avatar,\ who\ fights\ alongside\ Trunks\ and\ many\ other\ characters.\ Will\ the\ strength\ of\ this\ partnership\ be\ enough\ to\ intervene\ in\ fights\ and\ restore\ the\ Dragon\ Ball\ timeline\ we\ know?\ New\ features\ include\ the\ mysterious\ Toki\ Toki\ City,\ new\ gameplay\ mechanics,\ new\ character\ animations\ and\ many\ other\ amazing\ features\ to\ be\ unveiled\ soon\!=
+FOR\ THE\ FIRST\ TIME\ EVER,\ THE\ DRAGON\ BALL\ UNIVERSE\ IS\ COMING\ TO\ STEAM\!<br><br>DRAGON\ BALL\ XENOVERSE\ revisits\ famous\ battles\ from\ the\ series\ through\ your\ custom\ Avatar,\ who\ fights\ alongside\ Trunks\ and\ many\ other\ characters.\ Will\ the\ strength\ of\ this\ partnership\ be\ enough\ to\ intervene\ in\ fights\ and\ restore\ the\ Dragon\ Ball\ timeline\ we\ know?\ New\ features\ include\ the\ mysterious\ Toki\ Toki\ City,\ new\ gameplay\ mechanics,\ new\ character\ animations\ and\ many\ other\ amazing\ features\ to\ be\ unveiled\ soon\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider: The Dagger Of Xian/application.js:2
-!Fan\ Game\ Tomb\ Raider\ 2\ Remake\ by\ Nicobass.=
+Fan\ Game\ Tomb\ Raider\ 2\ Remake\ by\ Nicobass.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry/application.js:1
-!Far\ Cry=
+Far\ Cry=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry 3 - Blood Dragon/application.js:1
-!Far\ Cry\ 3\ -\ Blood\ Dragon=
+Far\ Cry\ 3\ -\ Blood\ Dragon=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry 2/application.js:1
-!Far\ Cry\u00ae\ 2=
+Far\ Cry\u00ae\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry 3 - Blood Dragon/application.js:2
-!Far\ Cry\u00ae\ 3\:\ Blood\ Dragon\ is\ THE\ Kick-Ass\ Cyber\ Shooter.Welcome\ to\ an\ 80\u2019s\ vision\ of\ the\ future.\ The\ year\ is\ 2007\ and\ you\ are\ Sargent\ Rex\ Colt,\ a\ Mark\ IV\ Cyber\ Commando.\ Your\ mission\:\ get\ the\ girl,\ kill\ the\ baddies,\ and\ save\ the\ world.=
+Far\ Cry\u00ae\ 3\:\ Blood\ Dragon\ is\ THE\ Kick-Ass\ Cyber\ Shooter.Welcome\ to\ an\ 80\u2019s\ vision\ of\ the\ future.\ The\ year\ is\ 2007\ and\ you\ are\ Sargent\ Rex\ Colt,\ a\ Mark\ IV\ Cyber\ Commando.\ Your\ mission\:\ get\ the\ girl,\ kill\ the\ baddies,\ and\ save\ the\ world.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Filesystem/Extract/script.js:1
-!File\ Extractors=
+File\ Extractors=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Filesystem/Files/script.js:1
-!File\ Utilities=
+File\ Utilities=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Filesystem/application.js:1
-!Filesystem\ Utils=
+Filesystem\ Utils=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Quantum Conundrum/application.js:2
-!Find\ and\ rescue\ your\ uncle\ by\ using\ his\ newest\ invention\ to\ work\ your\ way\ through\ a\ crazy\ complex\ mansion\ as\ you\ switch\ between\ dimensions\ and\ solve\ puzzles\!=
+Find\ and\ rescue\ your\ uncle\ by\ using\ his\ newest\ invention\ to\ work\ your\ way\ through\ a\ crazy\ complex\ mansion\ as\ you\ switch\ between\ dimensions\ and\ solve\ puzzles\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/FlatOut/application.js:1
-!FlatOut=
+FlatOut=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/FlatOut/application.js:2
-!FlatOut\ is\ adrenaline-filled\ muscle\ car\ racing\ game\ packed\ with\ explosive\ physics,\ spectacular\ effects\ and\ graphics,\ innovative\ game\ play\ mechanics\ and\ good\ old\ fun\!=
+FlatOut\ is\ adrenaline-filled\ muscle\ car\ racing\ game\ packed\ with\ explosive\ physics,\ spectacular\ effects\ and\ graphics,\ innovative\ game\ play\ mechanics\ and\ good\ old\ fun\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Beyond Good and Evil/application.js:2
-!For\ centuries,\ the\ planet\ Hyllis\ has\ been\ bombarded\ by\ a\ relentless\ alien\ race.\ Skeptical\ of\ her\ government's\ inability\ to\ repel\ the\ invaders,\ a\ rebellious\ action\ reporter\ named\ Jade\ sets\ out\ to\ capture\ the\ truth.=
+For\ centuries,\ the\ planet\ Hyllis\ has\ been\ bombarded\ by\ a\ relentless\ alien\ race.\ Skeptical\ of\ her\ government's\ inability\ to\ repel\ the\ invaders,\ a\ rebellious\ action\ reporter\ named\ Jade\ sets\ out\ to\ capture\ the\ truth.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight - Jedi Academy/application.js:2
-!Forge\ your\ weapon\ and\ follow\ the\ path\ of\ the\ Jedi\ Jedi\ Knight\:\ Jedi\ Academy\ is\ the\ latest\ installment\ of\ the\ highly\ acclaimed\ Jedi\ Knight\ series.\ Take\ on\ the\ role\ of\ a\ new\ student\ eager\ to\ learn\ the\ ways\ of\ the\ Force\ from\ Jedi\ Master\ Luke\ Skywalker.=
+Forge\ your\ weapon\ and\ follow\ the\ path\ of\ the\ Jedi\ Jedi\ Knight\:\ Jedi\ Academy\ is\ the\ latest\ installment\ of\ the\ highly\ acclaimed\ Jedi\ Knight\ series.\ Take\ on\ the\ role\ of\ a\ new\ student\ eager\ to\ learn\ the\ ways\ of\ the\ Force\ from\ Jedi\ Master\ Luke\ Skywalker.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Call of Juarez Gunslinger/application.js:2
-!From\ the\ dust\ of\ a\ gold\ mine\ to\ the\ dirt\ of\ a\ saloon,\ Call\ of\ Juarez\u00ae\ Gunslinger\ is\ a\ real\ homage\ to\ the\ Wild\ West\ tales.\ Live\ the\ epic\ and\ violent\ journey\ of\ a\ ruthless\ bounty\ hunter\ on\ the\ trail\ of\ the\ West\u2019s\ most\ notorious\ outlaws.=
+From\ the\ dust\ of\ a\ gold\ mine\ to\ the\ dirt\ of\ a\ saloon,\ Call\ of\ Juarez\u00ae\ Gunslinger\ is\ a\ real\ homage\ to\ the\ Wild\ West\ tales.\ Live\ the\ epic\ and\ violent\ journey\ of\ a\ ruthless\ bounty\ hunter\ on\ the\ trail\ of\ the\ West\u2019s\ most\ notorious\ outlaws.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/category.js:1
-!Functions=
+Functions=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/category.js:1
-!Games=
+Games=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Goodbye Deponia/application.js:1
-!Goodbye\ Deponia=
+Goodbye\ Deponia=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Graphics/category.js:1
-!Graphics=
+Graphics=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Guild Wars 2/application.js:1
-!Guild\ Wars\ 2=
+Guild\ Wars\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Guild Wars 2/application.js:2
-!Guild\ Wars\ 2\ defines\ the\ future\ of\ online\ roleplaying\ games\ with\ action-oriented\ combat,\ customized\ personal\ storylines,\ epic\ dynamic\ events,\ world-class\ PvP,\ and\ no\ subscription\ fees\!=
+Guild\ Wars\ 2\ defines\ the\ future\ of\ online\ roleplaying\ games\ with\ action-oriented\ combat,\ customized\ personal\ storylines,\ epic\ dynamic\ events,\ world-class\ PvP,\ and\ no\ subscription\ fees\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Caesar III/application.js:2
-!Hail\ Governor,\ your\ city\ awaits.<br><br>As\ a\ provincial\ governor\ charged\ with\ spreading\ the\ glory\ of\ Rome\ our\ mission\ is\ clear\:\ build\ cities,\ foster\ trade\ and\ industry,\ make\ money.\ How\ you\ accomplish\ this\ is\ entirely\ up\ to\ you.\ Gain\ wealth\ and\ power,\ make\ a\ career\ out\ of\ pleasing\ the\ emperor,\ battle\ Barbarians\ and\ repel\ invaders\ or\ concentrate\ on\ building\ the\ next\ Eternal\ City.\ Fail\ and\ you\u2019ll\ end\ up\ as\ lunch\ for\ the\ lions.\ Prove\ your\ strength\ of\ mind\ and\ spirit\ and\ you\ just\ may\ be\ crowned\ Caesar\!=
+Hail\ Governor,\ your\ city\ awaits.<br><br>As\ a\ provincial\ governor\ charged\ with\ spreading\ the\ glory\ of\ Rome\ our\ mission\ is\ clear\:\ build\ cities,\ foster\ trade\ and\ industry,\ make\ money.\ How\ you\ accomplish\ this\ is\ entirely\ up\ to\ you.\ Gain\ wealth\ and\ power,\ make\ a\ career\ out\ of\ pleasing\ the\ emperor,\ battle\ Barbarians\ and\ repel\ invaders\ or\ concentrate\ on\ building\ the\ next\ Eternal\ City.\ Fail\ and\ you\u2019ll\ end\ up\ as\ lunch\ for\ the\ lions.\ Prove\ your\ strength\ of\ mind\ and\ spirit\ and\ you\ just\ may\ be\ crowned\ Caesar\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hearthstone/application.js:1
-!Hearthstone=
+Hearthstone=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/18 Wheels of Steel Across America/application.js:2
-!Heed\ the\ call\ of\ the\ open\ road,\ throw\ the\ gears\ in\ motion\ and\ take\ off\ in\ a\ tractor\ trailer.\ Drive\ faster\ than\ your\ competition,\ haul\ your\ cargo\ across\ the\ entire\ United\ States\ and\ feel\ the\ wind\ in\ your\ face\ as\ you\ control\ your\ own\ destiny.\ Blast\ the\ horn\ and\ build\ a\ career\ in\ the\ fast-paced\ world\ of\ trucking.=
+Heed\ the\ call\ of\ the\ open\ road,\ throw\ the\ gears\ in\ motion\ and\ take\ off\ in\ a\ tractor\ trailer.\ Drive\ faster\ than\ your\ competition,\ haul\ your\ cargo\ across\ the\ entire\ United\ States\ and\ feel\ the\ wind\ in\ your\ face\ as\ you\ control\ your\ own\ destiny.\ Blast\ the\ horn\ and\ build\ a\ career\ in\ the\ fast-paced\ world\ of\ trucking.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Heroes of the Storm/application.js:1
-!Heroes\ of\ the\ Storm=
+Heroes\ of\ the\ Storm=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Heroes of the Storm/application.js:2
-!Heroes\ of\ the\ Storm\ (HotS)\ is\ a\ multiplayer\ online\ battle\ arena\ video\ game\ developed\ and\ published\ by\ Blizzard\ Entertainment.=
+Heroes\ of\ the\ Storm\ (HotS)\ is\ a\ multiplayer\ online\ battle\ arena\ video\ game\ developed\ and\ published\ by\ Blizzard\ Entertainment.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells/application.js:1
-!Hexcells=
+Hexcells=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells Infinite/application.js:1
-!Hexcells\ Infinite=
+Hexcells\ Infinite=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells Infinite/application.js:2
-!Hexcells\ Infinite\ is\ the\ third\ game\ in\ the\ series\ of\ ambient\ logic\ puzzle\ games.<br><br>It\ includes\ a\ new\ set\ of\ 36\ puzzles\ as\ well\ as\ a\ random\ puzzle\ generator\ and\ now\ supports\ mid-level\ saving\ and\ cross\ platform\ cloud\ saves.<br><br>The\ level\ generator\ uses\ an\ 8\ digit\ seed\ number\ to\ generate\ each\ puzzle\ so\ they\ can\ easily\ be\ shared.=
+Hexcells\ Infinite\ is\ the\ third\ game\ in\ the\ series\ of\ ambient\ logic\ puzzle\ games.<br><br>It\ includes\ a\ new\ set\ of\ 36\ puzzles\ as\ well\ as\ a\ random\ puzzle\ generator\ and\ now\ supports\ mid-level\ saving\ and\ cross\ platform\ cloud\ saves.<br><br>The\ level\ generator\ uses\ an\ 8\ digit\ seed\ number\ to\ generate\ each\ puzzle\ so\ they\ can\ easily\ be\ shared.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells Plus/application.js:1
-!Hexcells\ Plus=
+Hexcells\ Plus=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells Plus/application.js:2
-!Hexcells\ Plus\ is\ a\ standalone\ expansion\ to\ Hexcells\ that\ contains\ 36\ new\ and\ more\ challenging\ puzzles.=
+Hexcells\ Plus\ is\ a\ standalone\ expansion\ to\ Hexcells\ that\ contains\ 36\ new\ and\ more\ challenging\ puzzles.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells/application.js:2
-!Hexcells\ is\ an\ ambient\ logic\ puzzle\ game\ for\ PC,\ Mac\ and\ Linux.=
+Hexcells\ is\ an\ ambient\ logic\ puzzle\ game\ for\ PC,\ Mac\ and\ Linux.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Icy Tower/application.js:1
-!Icy\ Tower\ 1.5=
+Icy\ Tower\ 1.5=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Icy Tower/application.js:2
-!Icy\ Tower\ is\ a\ platform\ game\ set\ in\ a\ tower,\ where\ the\ player's\ goal\ is\ to\ jump\ from\ one\ floor\ to\ the\ next\ and\ go\ as\ high\ as\ possible\ without\ falling\ and\ plunging\ off\ the\ screen.=
+Icy\ Tower\ is\ a\ platform\ game\ set\ in\ a\ tower,\ where\ the\ player's\ goal\ is\ to\ jump\ from\ one\ floor\ to\ the\ next\ and\ go\ as\ high\ as\ possible\ without\ falling\ and\ plunging\ off\ the\ screen.=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Total War Rome II/Steam/script.js:21
-!If\ you\ are\ experiencing\ issues\ with\ game\ (e.g.\ it\ crashes\ at\ start\ or\ rendering\ is\ broken),\ you\ can\ try\ to\ enable\ de\ OpenGL\ renderer,\ by\ modifying\ \:\n\n\ gfx_device_type\ to\ 2\n\n\ in\ the\ {0}/drive_c/users/USERNAME/Application\ Data/The\ Creative\ Assembly/Rome2/scripts/preferences_script.txt\ =
+If\ you\ are\ experiencing\ issues\ with\ game\ (e.g.\ it\ crashes\ at\ start\ or\ rendering\ is\ broken),\ you\ can\ try\ to\ enable\ de\ OpenGL\ renderer,\ by\ modifying\ \:\n\n\ gfx_device_type\ to\ 2\n\n\ in\ the\ {0}/drive_c/users/USERNAME/Application\ Data/The\ Creative\ Assembly/Rome2/scripts/preferences_script.txt\ =
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Mass Effect/Steam/script.js:11
-!If\ you\ have\ sound\ issues,\ please\ edit\ the\ BIOEngine.ini\ and/or\ BaseEngine.ini\ file\ in\ {0}/drive_c/Program\ Files/Steam/steamapps/common/Mass\ Effect/Engine/Config/\n\nAnd\ add\ the\ following\ under\ [ISACTAudio.ISACTAudioDevice]\ \:\n\nDeviceName\=Generic\ Software\nUseEffectsProcessing\=False\n\n=
+If\ you\ have\ sound\ issues,\ please\ edit\ the\ BIOEngine.ini\ and/or\ BaseEngine.ini\ file\ in\ {0}/drive_c/Program\ Files/Steam/steamapps/common/Mass\ Effect/Engine/Config/\n\nAnd\ add\ the\ following\ under\ [ISACTAudio.ISACTAudioDevice]\ \:\n\nDeviceName\=Generic\ Software\nUseEffectsProcessing\=False\n\n=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/ImgBurn/application.js:1
-!ImgBurn=
+ImgBurn=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/ImgBurn/application.js:2
-!ImgBurn\ is\ a\ lightweight\ CD\ /\ DVD\ /\ HD\ DVD\ /\ Blu-ray\ burning\ application.=
+ImgBurn\ is\ a\ lightweight\ CD\ /\ DVD\ /\ HD\ DVD\ /\ Blu-ray\ burning\ application.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Age of Empires III: Complete Collection/application.js:2
-!Immerse\ yourself\ in\ the\ award-winning\ strategy\ experience.\ Microsoft\ Studios\ brings\ you\ three\ epic\ Age\ of\ Empires\ III\ games\ in\ one\ monumental\ collection\ for\ the\ first\ time.\ Command\ mighty\ European\ powers\ looking\ to\ explore\ new\ lands\ in\ the\ New\ World;\ or\ jump\ eastward\ to\ Asia\ and\ determine\ the\ outcome\ of\ its\ struggles\ for\ power.=
+Immerse\ yourself\ in\ the\ award-winning\ strategy\ experience.\ Microsoft\ Studios\ brings\ you\ three\ epic\ Age\ of\ Empires\ III\ games\ in\ one\ monumental\ collection\ for\ the\ first\ time.\ Command\ mighty\ European\ powers\ looking\ to\ explore\ new\ lands\ in\ the\ New\ World;\ or\ jump\ eastward\ to\ Asia\ and\ determine\ the\ outcome\ of\ its\ struggles\ for\ power.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Civilization V/application.js:2
-!In\ Civilization\ V,\ the\ player\ leads\ a\ civilization\ from\ prehistoric\ times\ into\ the\ future\ on\ a\ procedurally\ generated\ map,\ achieving\ one\ of\ a\ number\ of\ different\ victory\ conditions\ through\ research,\ exploration,\ diplomacy,\ expansion,\ economic\ development,\ government\ and\ military\ conquest.=
+In\ Civilization\ V,\ the\ player\ leads\ a\ civilization\ from\ prehistoric\ times\ into\ the\ future\ on\ a\ procedurally\ generated\ map,\ achieving\ one\ of\ a\ number\ of\ different\ victory\ conditions\ through\ research,\ exploration,\ diplomacy,\ expansion,\ economic\ development,\ government\ and\ military\ conquest.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prey/application.js:2
-!In\ Prey,\ you\ awaken\ aboard\ Talos\ I,\ a\ space\ station\ orbiting\ the\ moon\ in\ the\ year\ 2032.\ You\ are\ the\ key\ subject\ of\ an\ experiment\ meant\ to\ alter\ humanity\ forever\ \u2013\ but\ things\ have\ gone\ terribly\ wrong.\ The\ space\ station\ has\ been\ overrun\ by\ hostile\ aliens\ and\ you\ are\ now\ being\ hunted.=
+In\ Prey,\ you\ awaken\ aboard\ Talos\ I,\ a\ space\ station\ orbiting\ the\ moon\ in\ the\ year\ 2032.\ You\ are\ the\ key\ subject\ of\ an\ experiment\ meant\ to\ alter\ humanity\ forever\ \u2013\ but\ things\ have\ gone\ terribly\ wrong.\ The\ space\ station\ has\ been\ overrun\ by\ hostile\ aliens\ and\ you\ are\ now\ being\ hunted.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Star Trek Online/application.js:2
-!In\ Star\ Trek\ Online,\ the\ Star\ Trek\ universe\ appears\ for\ the\ first\ time\ on\ a\ truly\ massive\ scale.\ Players\ take\ the\ captain's\ chair\ as\ they\ command\ their\ own\ starship\ and\ crew.\ Explore\ strange\ new\ worlds,\ seek\ out\ new\ life\ and\ new\ civilizations,\ and\ boldly\ go\ where\ no\ one\ has\ gone\ before.=
+In\ Star\ Trek\ Online,\ the\ Star\ Trek\ universe\ appears\ for\ the\ first\ time\ on\ a\ truly\ massive\ scale.\ Players\ take\ the\ captain's\ chair\ as\ they\ command\ their\ own\ starship\ and\ crew.\ Explore\ strange\ new\ worlds,\ seek\ out\ new\ life\ and\ new\ civilizations,\ and\ boldly\ go\ where\ no\ one\ has\ gone\ before.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mirror's Edge/application.js:2
-!In\ a\ city\ where\ information\ is\ heavily\ monitored,\ agile\ couriers\ called\ Runners\ transport\ sensitive\ data\ away\ from\ prying\ eyes.\ In\ this\ seemingly\ utopian\ paradise,\ a\ crime\ has\ been\ committed,\ your\ sister\ has\ been\ framed\ and\ now\ you\ are\ being\ hunted.=
+In\ a\ city\ where\ information\ is\ heavily\ monitored,\ agile\ couriers\ called\ Runners\ transport\ sensitive\ data\ away\ from\ prying\ eyes.\ In\ this\ seemingly\ utopian\ paradise,\ a\ crime\ has\ been\ committed,\ your\ sister\ has\ been\ framed\ and\ now\ you\ are\ being\ hunted.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warlock - Master of the Arcane/application.js:2
-!In\ a\ time\ of\ chaotic\ upheaval,\ the\ player\ takes\ the\ role\ of\ a\ great\ mage,\ a\ warlord\ vying\ for\ ultimate\ power.\ Your\ mission\ is\ to\ build\ an\ empire,\ expand\ your\ borders,\ research\ new\ spells\ and\ conquer\ your\ enemies.\ Become\ the\ ultimate\ Warlock\ and\ rule\ over\ all\ of\ Ardania\!=
+In\ a\ time\ of\ chaotic\ upheaval,\ the\ player\ takes\ the\ role\ of\ a\ great\ mage,\ a\ warlord\ vying\ for\ ultimate\ power.\ Your\ mission\ is\ to\ build\ an\ empire,\ expand\ your\ borders,\ research\ new\ spells\ and\ conquer\ your\ enemies.\ Become\ the\ ultimate\ Warlock\ and\ rule\ over\ all\ of\ Ardania\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Splinter Cell/application.js:2
-!Infiltrate\ terrorists'\ positions,\ acquire\ critical\ intelligence\ by\ any\ means\ necessary,\ execute\ with\ extreme\ prejudice,\ and\ exit\ without\ a\ trace\!\ You\ are\ Sam\ Fisher,\ a\ highly\ trained\ secret\ operative\ of\ the\ NSA's\ secret\ arm\:\ Third\ Echelon.=
+Infiltrate\ terrorists'\ positions,\ acquire\ critical\ intelligence\ by\ any\ means\ necessary,\ execute\ with\ extreme\ prejudice,\ and\ exit\ without\ a\ trace\!\ You\ are\ Sam\ Fisher,\ a\ highly\ trained\ secret\ operative\ of\ the\ NSA's\ secret\ arm\:\ Third\ Echelon.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Installer Script/script.js:1
-!Installer\ Script=
+Installer\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:480
-!Installing\ version\:\ =
+Installing\ version\:\ =
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/corefonts/script.js:84
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/corefonts/script.js:90
 #: /home/klara/.Phoenicis/Scripts/Applications/Internet/Internet Explorer 6.0/Online/script.js:77
 #: /home/klara/.Phoenicis/Scripts/Applications/Internet/Internet Explorer 7.0/Online/script.js:217
-!Installing\ {0}\ ...=
+Installing\ {0}\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/category.js:1
-!Internet=
+Internet=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/Internet Explorer 6.0/application.js:1
-!Internet\ Explorer\ 6.0=
+Internet\ Explorer\ 6.0=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/Internet Explorer 7.0/application.js:1
-!Internet\ Explorer\ 7.0=
+Internet\ Explorer\ 7.0=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/Internet Explorer 6.0/application.js:2
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/Internet Explorer 7.0/application.js:2
-!Internet\ Explorer\ is\ an\ old\ web\ browser.<br\ />You\ may\ need\ it\ if\ you\ want\ to\ test\ a\ website\ compatibility,\ you\ should\ not\ use\ it\ to\ navigate.\ =
+Internet\ Explorer\ is\ an\ old\ web\ browser.<br\ />You\ may\ need\ it\ if\ you\ want\ to\ test\ a\ website\ compatibility,\ you\ should\ not\ use\ it\ to\ navigate.\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Net/Resource/script.js:1
-!Internet\ Resource=
+Internet\ Resource=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/It came from space and ate our brains/application.js:1
-!It\ came\ from\ space,\ and\ ate\ our\ brains=
+It\ came\ from\ space,\ and\ ate\ our\ brains=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight - Mysteries of the Sith/application.js:2
-!It\ is\ five\ years\ after\ Kyle's\ victory\ over\ the\ seven\ dark\ Jedi.\ Invading\ Imperial\ forces\ advance\ upon\ a\ quiet\ Rebel\ outpost,\ interrupting\ Kyle's\ training\ of\ a\ brave\ new\ Jedi,\ Mara\ Jade.\ First\ introduced\ in\ Timothy\ Zahn's\ award-winning\ Star\ Wars\ novel,\ Heir\ to\ the\ Empire,\ Mara\ Jade\ blends\ her\ past\ experiences\ as\ a\ one\ time\ smuggler\ and\ Emperor's\ Hand\ with\ her\ apprenticeship\ as\ a\ Jedi\ Knight.=
+It\ is\ five\ years\ after\ Kyle's\ victory\ over\ the\ seven\ dark\ Jedi.\ Invading\ Imperial\ forces\ advance\ upon\ a\ quiet\ Rebel\ outpost,\ interrupting\ Kyle's\ training\ of\ a\ brave\ new\ Jedi,\ Mara\ Jade.\ First\ introduced\ in\ Timothy\ Zahn's\ award-winning\ Star\ Wars\ novel,\ Heir\ to\ the\ Empire,\ Mara\ Jade\ blends\ her\ past\ experiences\ as\ a\ one\ time\ smuggler\ and\ Emperor's\ Hand\ with\ her\ apprenticeship\ as\ a\ Jedi\ Knight.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight: Dark Forces II/application.js:2
-!Jedi\ Knight\:\ Dark\ Forces\ II\ picks\ up\ where\ the\ award-winning\ Dark\ Forces\u2122\ game\ left\ off...with\ even\ more\ features\ and\ firepower\ in\ dazzling\ 3D\ graphics.\ As\ Kyle\ Katarn,\ you\ must\ acquire\ a\ lightsaber\ and\ learn\ the\ ways\ of\ the\ Force\ to\ become\ a\ Jedi\ Knight.=
+Jedi\ Knight\:\ Dark\ Forces\ II\ picks\ up\ where\ the\ award-winning\ Dark\ Forces\u2122\ game\ left\ off...with\ even\ more\ features\ and\ firepower\ in\ dazzling\ 3D\ graphics.\ As\ Kyle\ Katarn,\ you\ must\ acquire\ a\ lightsaber\ and\ learn\ the\ ways\ of\ the\ Force\ to\ become\ a\ Jedi\ Knight.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Battlefront II/application.js:2
-!Join\ the\ rise\ of\ Darth\ Vader\u2019s\ elite\ 501st\ Legion\ of\ Stormtroopers\ as\ you\ fight\ through\ an\ all\ new\ story-based\ saga\ where\ every\ action\ you\ take\ impacts\ the\ battlefront\ and,\ ultimately,\ the\ fate\ of\ the\ Star\ Wars\ galaxy.=
+Join\ the\ rise\ of\ Darth\ Vader\u2019s\ elite\ 501st\ Legion\ of\ Stormtroopers\ as\ you\ fight\ through\ an\ all\ new\ story-based\ saga\ where\ every\ action\ you\ take\ impacts\ the\ battlefront\ and,\ ultimately,\ the\ fate\ of\ the\ Star\ Wars\ galaxy.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Kill Wine Processes/script.js:1
-!Kill\ processes=
+Kill\ processes=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Epic Games Launcher/application.js:2
-!Launcher\ for\ Unreal\ Engine,\ Unreal\ Tournament,\ Paragon\ etc.=
+Launcher\ for\ Unreal\ Engine,\ Unreal\ Tournament,\ Paragon\ etc.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/League of Legends/application.js:1
-!League\ of\ Legends=
+League\ of\ Legends=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/League of Legends/application.js:2
-!League\ of\ Legends\ is\ a\ fast-paced,\ competitive\ online\ game\ that\ blends\ the\ speed\ and\ intensity\ of\ an\ RTS\ with\ RPG\ elements.\ Two\ teams\ of\ powerful\ champions,\ each\ with\ a\ unique\ design\ and\ playstyle,\ battle\ head-to-head\ across\ multiple\ battlefields\ and\ game\ modes.\ With\ an\ ever-expanding\ roster\ of\ champions,\ frequent\ updates\ and\ a\ thriving\ tournament\ scene,\ League\ of\ Legends\ offers\ endless\ replayability\ for\ players\ of\ every\ skill\ level.=
+League\ of\ Legends\ is\ a\ fast-paced,\ competitive\ online\ game\ that\ blends\ the\ speed\ and\ intensity\ of\ an\ RTS\ with\ RPG\ elements.\ Two\ teams\ of\ powerful\ champions,\ each\ with\ a\ unique\ design\ and\ playstyle,\ battle\ head-to-head\ across\ multiple\ battlefields\ and\ game\ modes.\ With\ an\ ever-expanding\ roster\ of\ champions,\ frequent\ updates\ and\ a\ thriving\ tournament\ scene,\ League\ of\ Legends\ offers\ endless\ replayability\ for\ players\ of\ every\ skill\ level.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed: Brotherhood/application.js:2
-!Live\ and\ breathe\ as\ Ezio,\ a\ legendary\ Master\ Assassin,\ in\ his\ enduring\ struggle\ against\ the\ powerful\ Templar\ order.<br><br>He\ must\ journey\ into\ Italy\u2019s\ greatest\ city,\ Rome,\ center\ of\ power,\ greed\ and\ corruption\ to\ strike\ at\ the\ heart\ of\ the\ enemy.\ Defeating\ the\ corrupt\ tyrants\ entrenched\ there\ will\ require\ not\ only\ strength,\ but\ leadership,\ as\ Ezio\ commands\ an\ entire\ brotherhood\ of\ assassins\ who\ will\ rally\ to\ his\ side.\ Only\ by\ working\ together\ can\ the\ assassins\ defeat\ their\ mortal\ enemies\ and\ prevent\ the\ extinction\ of\ their\ order.=
+Live\ and\ breathe\ as\ Ezio,\ a\ legendary\ Master\ Assassin,\ in\ his\ enduring\ struggle\ against\ the\ powerful\ Templar\ order.<br><br>He\ must\ journey\ into\ Italy\u2019s\ greatest\ city,\ Rome,\ center\ of\ power,\ greed\ and\ corruption\ to\ strike\ at\ the\ heart\ of\ the\ enemy.\ Defeating\ the\ corrupt\ tyrants\ entrenched\ there\ will\ require\ not\ only\ strength,\ but\ leadership,\ as\ Ezio\ commands\ an\ entire\ brotherhood\ of\ assassins\ who\ will\ rally\ to\ his\ side.\ Only\ by\ working\ together\ can\ the\ assassins\ defeat\ their\ mortal\ enemies\ and\ prevent\ the\ extinction\ of\ their\ order.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/LocalInstaller/Local/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Microsoft Office 2013/Local/script.js:1
@@ -552,92 +552,92 @@
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis II/Local/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Resident Evil 3/Local/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls IV: Oblivion/Local/script.js:1
-!Local=
+Local=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Rainbow Six 3 : Raven Shield/Local (1.0->1.6)/script.js:1
-!Local\ (1.0->1.6)=
+Local\ (1.0->1.6)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider: The Dagger Of Xian/Local (Demo)/script.js:1
-!Local\ (Demo)=
+Local\ (Demo)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Origin/Local (Legacy)/script.js:1
-!Local\ (Legacy)=
+Local\ (Legacy)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/LocalInstaller/application.js:1
-!Local\ Installer=
+Local\ Installer=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Local Installer Script/script.js:1
-!Local\ Installer\ Script=
+Local\ Installer\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Borderlands/application.js:2
-!Lock,\ Load,\ &\ Face\ the\ Madness<br><br>Get\ ready\ for\ the\ mind\ blowing\ insanity\!\ Play\ as\ one\ of\ four\ trigger-happy\ mercenaries\ and\ take\ out\ everything\ that\ stands\ in\ your\ way\!<br><br>With\ its\ addictive\ action,\ frantic\ first-person\ shooter\ combat,\ massive\ arsenal\ of\ weaponry,\ RPG\ elements\ and\ four-player\ co-op*,\ Borderlands\ is\ a\ breakthrough\ experience\ that\ challenges\ all\ the\ conventions\ of\ modern\ shooters.\ Borderlands\ places\ you\ in\ the\ role\ of\ a\ mercenary\ on\ the\ lawless\ and\ desolate\ planet\ of\ Pandora,\ hell-bent\ on\ finding\ a\ legendary\ stockpile\ of\ powerful\ alien\ technology\ known\ as\ The\ Vault.=
+Lock,\ Load,\ &\ Face\ the\ Madness<br><br>Get\ ready\ for\ the\ mind\ blowing\ insanity\!\ Play\ as\ one\ of\ four\ trigger-happy\ mercenaries\ and\ take\ out\ everything\ that\ stands\ in\ your\ way\!<br><br>With\ its\ addictive\ action,\ frantic\ first-person\ shooter\ combat,\ massive\ arsenal\ of\ weaponry,\ RPG\ elements\ and\ four-player\ co-op*,\ Borderlands\ is\ a\ breakthrough\ experience\ that\ challenges\ all\ the\ conventions\ of\ modern\ shooters.\ Borderlands\ places\ you\ in\ the\ role\ of\ a\ mercenary\ on\ the\ lawless\ and\ desolate\ planet\ of\ Pandora,\ hell-bent\ on\ finding\ a\ legendary\ stockpile\ of\ powerful\ alien\ technology\ known\ as\ The\ Vault.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mafia II/application.js:1
-!Mafia\ II=
+Mafia\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mass Effect/application.js:1
-!Mass\ Effect=
+Mass\ Effect=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mass Effect 2/application.js:1
-!Mass\ Effect\ 2=
+Mass\ Effect\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Medieval II: Total War/application.js:1
-!Medieval\ II\:\ Total\ War\u2122=
+Medieval\ II\:\ Total\ War\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rayman Legends/application.js:2
-!Michel\ Ancel,\ the\ celebrated\ creator\ of\ Rayman\u00ae,\ Beyond\ Good\ &\ Evil\u00ae,\ and\ the\ Raving\ Rabbids\u00ae,\ returns\ to\ unleash\ his\ innovative\ creativity\ on\ this\ new\ entry\ into\ the\ Rayman\u00ae\ franchise.<br><br>When\ Rayman,\ Globox,\ and\ the\ Teensies\ discover\ a\ mysterious\ tent\ filled\ with\ captivating\ paintings,\ they\ are\ suddenly\ transported\ to\ a\ series\ of\ mythical\ new\ worlds\!<br><br>Join\ them\ as\ they\ run,\ jump,\ and\ slap\ their\ way\ through\ each\ world\ to\ get\ home,\ save\ the\ day,\ and\ discover\ the\ secrets\ of\ the\ legendary\ paintings\!=
+Michel\ Ancel,\ the\ celebrated\ creator\ of\ Rayman\u00ae,\ Beyond\ Good\ &\ Evil\u00ae,\ and\ the\ Raving\ Rabbids\u00ae,\ returns\ to\ unleash\ his\ innovative\ creativity\ on\ this\ new\ entry\ into\ the\ Rayman\u00ae\ franchise.<br><br>When\ Rayman,\ Globox,\ and\ the\ Teensies\ discover\ a\ mysterious\ tent\ filled\ with\ captivating\ paintings,\ they\ are\ suddenly\ transported\ to\ a\ series\ of\ mythical\ new\ worlds\!<br><br>Join\ them\ as\ they\ run,\ jump,\ and\ slap\ their\ way\ through\ each\ world\ to\ get\ home,\ save\ the\ day,\ and\ discover\ the\ secrets\ of\ the\ legendary\ paintings\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Microsoft Office 2010/application.js:1
-!Microsoft\ Office\ 2010=
+Microsoft\ Office\ 2010=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Microsoft Office 2010/application.js:2
-!Microsoft\ Office\ 2010\ is\ a\ version\ of\ Microsoft\ Office,\ a\ productivity\ suite\ for\ Microsoft\ Windows.\ It\ is\ the\ successor\ to\ Microsoft\ Office\ 2007.=
+Microsoft\ Office\ 2010\ is\ a\ version\ of\ Microsoft\ Office,\ a\ productivity\ suite\ for\ Microsoft\ Windows.\ It\ is\ the\ successor\ to\ Microsoft\ Office\ 2007.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Microsoft Office 2013/application.js:1
-!Microsoft\ Office\ 2013=
+Microsoft\ Office\ 2013=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/Microsoft Office 2013/application.js:2
-!Microsoft\ Office\ 2013\ is\ a\ version\ of\ Microsoft\ Office,\ a\ productivity\ suite\ for\ Microsoft\ Windows.\ It\ is\ the\ successor\ to\ Microsoft\ Office\ 2010.=
+Microsoft\ Office\ 2013\ is\ a\ version\ of\ Microsoft\ Office,\ a\ productivity\ suite\ for\ Microsoft\ Windows.\ It\ is\ the\ successor\ to\ Microsoft\ Office\ 2010.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mirror's Edge/application.js:1
-!Mirror's\ Edge\u2122=
+Mirror's\ Edge\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Goodbye Deponia/application.js:2
-!More\ chaos,\ more\ destruction,\ more\ Rufus.\ Not\ one,\ not\ two,\ but\ three\ Rufuses\ cause\ all\ kinds\ of\ crazy\ mayhem\ in\ the\ long-awaited\ adventure\ comedy\ Goodbye\ Deponia\!=
+More\ chaos,\ more\ destruction,\ more\ Rufus.\ Not\ one,\ not\ two,\ but\ three\ Rufuses\ cause\ all\ kinds\ of\ crazy\ mayhem\ in\ the\ long-awaited\ adventure\ comedy\ Goodbye\ Deponia\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mount & Blade/application.js:1
-!Mount\ &\ Blade=
+Mount\ &\ Blade=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Multimedia/Mp3tag/application.js:1
-!Mp3tag=
+Mp3tag=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Multimedia/Mp3tag/application.js:2
-!Mp3tag\ is\ a\ powerful\ and\ yet\ easy-to-use\ tool\ to\ edit\ metadata\ of\ common\ audio\ formats\ where\ it\ supports\ ID3v1,\ ID3v2.3,\ ID3v2.4,\ iTunes\ MP4,\ WMA,\ Vorbis\ Comments\ and\ APE\ Tags.\ It\ also\ supports\ online\ database\ lookups\ from\ Amazon,\ Musicbraing,\ freedb\ or\ discogs\ for\ example\ to\ automatically\ gather\ proper\ tags\ and\ cover\ art.=
+Mp3tag\ is\ a\ powerful\ and\ yet\ easy-to-use\ tool\ to\ edit\ metadata\ of\ common\ audio\ formats\ where\ it\ supports\ ID3v1,\ ID3v2.3,\ ID3v2.4,\ iTunes\ MP4,\ WMA,\ Vorbis\ Comments\ and\ APE\ Tags.\ It\ also\ supports\ online\ database\ lookups\ from\ Amazon,\ Musicbraing,\ freedb\ or\ discogs\ for\ example\ to\ automatically\ gather\ proper\ tags\ and\ cover\ art.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Multimedia/category.js:1
-!Multimedia=
+Multimedia=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Net/application.js:1
-!Net\ Utils=
+Net\ Utils=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Niko: Through The Dream/application.js:2
-!Niko\ is\ a\ spiritual\ journey\ through\ the\ dreams,\ where\ adventure,\ puzzles\ and\ mysteries\ come\ together\ in\ an\ oneiric\ and\ minimalist\ world.\ Dare\ to\ dream\!=
+Niko\ is\ a\ spiritual\ journey\ through\ the\ dreams,\ where\ adventure,\ puzzles\ and\ mysteries\ come\ together\ in\ an\ oneiric\ and\ minimalist\ world.\ Dare\ to\ dream\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Niko: Through The Dream/application.js:1
-!Niko\:\ Through\ The\ Dream=
+Niko\:\ Through\ The\ Dream=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Development/Notepad++/application.js:1
-!Notepad++=
+Notepad++=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Development/Notepad++/application.js:2
-!Notepad++\ is\ a\ free\ (as\ in\ &quot;free\ speech&quot;\ and\ also\ as\ in\ &quot;free\ beer&quot;)\ source\ code\ editor\ and\ Notepad\ replacement\ that\ supports\ several\ languages.\ Running\ in\ the\ MS\ Windows\ environment,\ its\ use\ is\ governed\ by\ GPL\ License.<br><br>Based\ on\ a\ powerful\ editing\ component\ Scintilla,\ Notepad++\ is\ written\ in\ C++\ and\ uses\ pure\ Win32\ API\ and\ STL\ which\ ensures\ a\ higher\ execution\ speed\ and\ smaller\ program\ size.\ By\ optimizing\ as\ many\ routines\ as\ possible\ without\ losing\ user\ friendliness,\ Notepad++\ is\ trying\ to\ reduce\ the\ world\ carbon\ dioxide\ emissions.\ When\ using\ less\ CPU\ power,\ the\ PC\ can\ throttle\ down\ and\ reduce\ power\ consumption,\ resulting\ in\ a\ greener\ environment.<br><br>Source\:\ http\://notepad-plus.sourceforge.net/uk/site.htm=
+Notepad++\ is\ a\ free\ (as\ in\ &quot;free\ speech&quot;\ and\ also\ as\ in\ &quot;free\ beer&quot;)\ source\ code\ editor\ and\ Notepad\ replacement\ that\ supports\ several\ languages.\ Running\ in\ the\ MS\ Windows\ environment,\ its\ use\ is\ governed\ by\ GPL\ License.<br><br>Based\ on\ a\ powerful\ editing\ component\ Scintilla,\ Notepad++\ is\ written\ in\ C++\ and\ uses\ pure\ Win32\ API\ and\ STL\ which\ ensures\ a\ higher\ execution\ speed\ and\ smaller\ program\ size.\ By\ optimizing\ as\ many\ routines\ as\ possible\ without\ losing\ user\ friendliness,\ Notepad++\ is\ trying\ to\ reduce\ the\ world\ carbon\ dioxide\ emissions.\ When\ using\ less\ CPU\ power,\ the\ PC\ can\ throttle\ down\ and\ reduce\ power\ consumption,\ resulting\ in\ a\ greener\ environment.<br><br>Source\:\ http\://notepad-plus.sourceforge.net/uk/site.htm=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Office/category.js:1
-!Office=
+Office=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Wildlife Park 2/Local/script.js:14
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Wildlife Park 2/Steam/script.js:13
-!On\ first\ run\ the\ game\ might\ not\ go\ into\ full\ screen.\ If\ that\ happens\ go\ to\ options\ and\ set\ the\ resolution\ to\ 1280x960.\ You\ will\ be\ asked\ to\ close\ the\ game\ in\ order\ to\ apply\ the\ new\ settings.\ Click\ Yes.\ Once\ you\ start\ the\ game\ again\ you\ should\ see\ a\ window\ where\ you\ can\ set\ your\ game\ resolution\ to\ match\ your\ screen.=
+On\ first\ run\ the\ game\ might\ not\ go\ into\ full\ screen.\ If\ that\ happens\ go\ to\ options\ and\ set\ the\ resolution\ to\ 1280x960.\ You\ will\ be\ asked\ to\ close\ the\ game\ in\ order\ to\ apply\ the\ new\ settings.\ Click\ Yes.\ Once\ you\ start\ the\ game\ again\ you\ should\ see\ a\ window\ where\ you\ can\ set\ your\ game\ resolution\ to\ match\ your\ screen.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/OnlineInstaller/Online/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/Internet Explorer 6.0/Online/script.js:1
@@ -669,91 +669,91 @@
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/7-zip/Online/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/Soundplant/Online/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Multimedia/Mp3tag/Online/script.js:1
-!Online=
+Online=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider: The Dagger Of Xian/Online (Demo)/script.js:1
-!Online\ (Demo)=
+Online\ (Demo)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Origin/Online (Legacy)/script.js:1
-!Online\ (Legacy)=
+Online\ (Legacy)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/OnlineInstaller/application.js:1
-!Online\ Installer=
+Online\ Installer=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Online Installer Script/script.js:1
-!Online\ Installer\ Script=
+Online\ Installer\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Wine Terminal Opener/script.js:1
-!Open\ a\ terminal=
+Open\ a\ terminal=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Origin/application.js:1
-!Origin=
+Origin=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Origin/application.js:2
-!Origin\ is\ EA's\ PC\ games\ portal.=
+Origin\ is\ EA's\ PC\ games\ portal.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Orwell: Keeping an Eye On You/application.js:1
-!Orwell\:\ Keeping\ an\ Eye\ On\ You=
+Orwell\:\ Keeping\ an\ Eye\ On\ You=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Other/category.js:1
-!Other=
+Other=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Overwatch/application.js:1
-!Overwatch=
+Overwatch=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Overwatch/application.js:2
-!Overwatch\ is\ a\ team-based\ multiplayer\ online\ first-person\ shooter\ video\ game.=
+Overwatch\ is\ a\ team-based\ multiplayer\ online\ first-person\ shooter\ video\ game.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/PAYDAY The Heist/application.js:1
-!PAYDAY\u2122\ The\ Heist=
+PAYDAY\u2122\ The\ Heist=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Burnout Paradise: The Ultimate Box/application.js:2
-!Paradise\ City\ is\ the\ largest\ and\ most\ dangerous\ setting\ yet\ for\ the\ best-selling\ Burnout\ series.\ The\ massive\ setting\ gives\ players\ an\ open-ended\ world\ to\ explore,\ as\ they\ race\ their\ vehicles\ through\ hundreds\ of\ miles\ of\ roads\ and\ underground\ passages\ with\ more\ than\ 70\ different\ cars.\ Speed\ through\ the\ streets\ from\ event\ to\ event,\ racking\ up\ points\ that\ are\ saved\ to\ your\ Paradise\ City\ driver\u2019s\ license.\ Earn\ the\ vaunted\ \u201cBurnout\u201d\ license\ by\ smashing\ through\ billboards,\ jumping\ ramps,\ and\ sustaining\ crashes\ with\ the\ improved\ damage\ system.=
+Paradise\ City\ is\ the\ largest\ and\ most\ dangerous\ setting\ yet\ for\ the\ best-selling\ Burnout\ series.\ The\ massive\ setting\ gives\ players\ an\ open-ended\ world\ to\ explore,\ as\ they\ race\ their\ vehicles\ through\ hundreds\ of\ miles\ of\ roads\ and\ underground\ passages\ with\ more\ than\ 70\ different\ cars.\ Speed\ through\ the\ streets\ from\ event\ to\ event,\ racking\ up\ points\ that\ are\ saved\ to\ your\ Paradise\ City\ driver\u2019s\ license.\ Earn\ the\ vaunted\ \u201cBurnout\u201d\ license\ by\ smashing\ through\ billboards,\ jumping\ ramps,\ and\ sustaining\ crashes\ with\ the\ improved\ damage\ system.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Graphics/Photofiltre/application.js:1
-!Photofiltre=
+Photofiltre=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/PhysX/script.js:1
-!PhysX=
+PhysX=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Uplay Script/script.js:85
-!Please\ close\ Uplay.=
+Please\ close\ Uplay.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Installer Script/script.js:23
-!Please\ enter\ the\ name\ of\ your\ application.=
+Please\ enter\ the\ name\ of\ your\ application.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Steam Script/script.js:104
-!Please\ follow\ the\ steps\ of\ the\ Steam\ setup.\n\nUncheck\ "Run\ Steam"\ or\ close\ Steam\ completely\ after\ the\ setup\ so\ that\ the\ installation\ of\ "{0}"\ can\ continue.=
+Please\ follow\ the\ steps\ of\ the\ Steam\ setup.\n\nUncheck\ "Run\ Steam"\ or\ close\ Steam\ completely\ after\ the\ setup\ so\ that\ the\ installation\ of\ "{0}"\ can\ continue.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/Uplay/script.js:16
-!Please\ follow\ the\ steps\ of\ the\ Uplay\ setup.\n\nUncheck\ "Run\ Uplay"\ or\ close\ Uplay\ completely\ after\ the\ setup\ so\ that\ the\ installation\ can\ continue.=
+Please\ follow\ the\ steps\ of\ the\ Uplay\ setup.\n\nUncheck\ "Run\ Uplay"\ or\ close\ Uplay\ completely\ after\ the\ setup\ so\ that\ the\ installation\ can\ continue.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Uplay Script/script.js:60
-!Please\ follow\ the\ steps\ of\ the\ Uplay\ setup.\n\nUncheck\ "Run\ Uplay"\ or\ close\ Uplay\ completely\ after\ the\ setup\ so\ that\ the\ installation\ of\ "{0}"\ can\ continue.=
+Please\ follow\ the\ steps\ of\ the\ Uplay\ setup.\n\nUncheck\ "Run\ Uplay"\ or\ close\ Uplay\ completely\ after\ the\ setup\ so\ that\ the\ installation\ of\ "{0}"\ can\ continue.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Zip Script/script.js:48
-!Please\ select\ the\ .zip\ file.=
+Please\ select\ the\ .zip\ file.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Online Installer Script/script.js:32
-!Please\ select\ the\ download\ URL.=
+Please\ select\ the\ download\ URL.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Installer Script/script.js:88
-!Please\ select\ the\ executable.=
+Please\ select\ the\ executable.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Local Installer Script/script.js:23
-!Please\ select\ the\ installation\ file.=
+Please\ select\ the\ installation\ file.=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Office/ElsterFormular/Online/script.js:10
-!Please\ select\ the\ installation\ file.\nYou\ can\ download\ it\ from\ https\://www.elster.de/elfo_down.php.=
+Please\ select\ the\ installation\ file.\nYou\ can\ download\ it\ from\ https\://www.elster.de/elfo_down.php.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Installer Script/script.js:38
-!Please\ select\ the\ wine\ architecture.=
+Please\ select\ the\ wine\ architecture.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Installer Script/script.js:52
-!Please\ select\ the\ wine\ distribution.=
+Please\ select\ the\ wine\ distribution.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Installer Script/script.js:66
-!Please\ select\ the\ wine\ version.=
+Please\ select\ the\ wine\ version.=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/corefonts/script.js:83
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/d3dx10/script.js:34
@@ -776,21 +776,21 @@
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Zip Script/script.js:44
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Zip Script/script.js:70
 #: /home/klara/.Phoenicis/Scripts/Applications/Internet/Internet Explorer 6.0/Online/script.js:73
-!Please\ wait\ ...=
+Please\ wait\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Steam Script/script.js:116
-!Please\ wait\ until\ Steam\ has\ finished\ the\ download\ ...=
+Please\ wait\ until\ Steam\ has\ finished\ the\ download\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/QuickScript/Uplay Script/script.js:77
-!Please\ wait\ until\ Uplay\ has\ finished\ the\ download\ ...=
+Please\ wait\ until\ Uplay\ has\ finished\ the\ download\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Net/Resource/script.js:80
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Net/Download/script.js:97
-!Please\ wait\ while\ {0}\ is\ downloaded\ ...=
+Please\ wait\ while\ {0}\ is\ downloaded\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Filesystem/Extract/script.js:57
 #: /home/klara/.Phoenicis/Scripts/Utils/Functions/Filesystem/Extract/script.js:133
-!Please\ wait\ while\ {0}\ is\ extracted\ ...=
+Please\ wait\ while\ {0}\ is\ extracted\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/vcrun2003/script.js:19
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/QuickTime 7.6/script.js:17
@@ -809,176 +809,176 @@
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/PhysX/script.js:18
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/vcrun2015/script.js:18
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/vcrun2015/script.js:29
-!Please\ wait\ while\ {0}\ is\ installed\ ...=
+Please\ wait\ while\ {0}\ is\ installed\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:274
-!Please\ wait\ while\ {0}\ is\ uninstalled\ ...=
+Please\ wait\ while\ {0}\ is\ uninstalled\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Engine/Object/script.js:462
-!Prefix\ seems\ to\ be\ 32bits=
+Prefix\ seems\ to\ be\ 32bits=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prehistorik/application.js:1
-!Prehistorik=
+Prehistorik=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prey/application.js:1
-!Prey=
+Prey=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prince Of Persia: Original/application.js:1
-!Prince\ of\ Persia\:\ Original=
+Prince\ of\ Persia\:\ Original=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Prince of Persia: The Sands of Time/application.js:1
-!Prince\ of\ Persia\u00ae\:\ The\ Sands\ of\ Time=
+Prince\ of\ Persia\u00ae\:\ The\ Sands\ of\ Time=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Pro Evolution Soccer 2018/application.js:1
-!Pro\ Evolution\ Soccer\ 2018=
+Pro\ Evolution\ Soccer\ 2018=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Q.U.B.E: Director's Cut/application.js:1
-!Q.U.B.E\:\ Director's\ Cut=
+Q.U.B.E\:\ Director's\ Cut=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Q.U.B.E: Director's Cut/application.js:2
-!Q.U.B.E\:\ Director's\ Cut\ is\ the\ definitive\ version\ of\ the\ brain-twisting\ first-person\ puzzler.\ Using\ special\ high-tech\ gloves\ to\ manipulate\ cubes\ in\ the\ environment,\ the\ player\ solves\ an\ array\ of\ conundrums\ -\ from\ physics-based\ challenges;\ to\ 3D\ jigsaws;\ to\ platform-based\ trials.\ =
+Q.U.B.E\:\ Director's\ Cut\ is\ the\ definitive\ version\ of\ the\ brain-twisting\ first-person\ puzzler.\ Using\ special\ high-tech\ gloves\ to\ manipulate\ cubes\ in\ the\ environment,\ the\ player\ solves\ an\ array\ of\ conundrums\ -\ from\ physics-based\ challenges;\ to\ 3D\ jigsaws;\ to\ platform-based\ trials.\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Quantum Conundrum/application.js:1
-!Quantum\ Conundrum=
+Quantum\ Conundrum=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Quick Script/script.js:1
-!Quick\ Script=
+Quick\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/application.js:1
-!QuickScript=
+QuickScript=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/application.js:2
-!QuickScripts\ for\ Wine.=
+QuickScripts\ for\ Wine.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/QuickTime 7.6/script.js:1
-!QuickTime\ 7.6=
+QuickTime\ 7.6=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Rainbow Six 3 : Raven Shield/application.js:2
-!Raven\ Shield\:\ Command\ an\ elite\ multinational\ squad\ of\ special\ operatives\ against\ hidden\ terrorist\ forces.\ In\ Tom\ Clancy's\ Rainbow\ Six\ 3\:\ Raven\ Shield,\ the\ third\ installment\ to\ the\ wildly\ popular\ Rainbow\ Six\ series,\ Team\ Rainbow\ faces\ the\ hidden\ global\ forces\ of\ a\ new\ and\ secretive\ foe.=
+Raven\ Shield\:\ Command\ an\ elite\ multinational\ squad\ of\ special\ operatives\ against\ hidden\ terrorist\ forces.\ In\ Tom\ Clancy's\ Rainbow\ Six\ 3\:\ Raven\ Shield,\ the\ third\ installment\ to\ the\ wildly\ popular\ Rainbow\ Six\ series,\ Team\ Rainbow\ faces\ the\ hidden\ global\ forces\ of\ a\ new\ and\ secretive\ foe.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rayman Legends/application.js:1
-!Rayman\u00ae\ Legends=
+Rayman\u00ae\ Legends=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rayman Origins/application.js:1
-!Rayman\u00ae\ Origins=
+Rayman\u00ae\ Origins=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mass Effect 2/application.js:2
-!Recruit.\ Explore.\ Control.Two\ years\ after\ Commander\ Shepard\ repelled\ invading\ Reapers\ bent\ on\ the\ destruction\ of\ organic\ life,\ a\ mysterious\ new\ enemy\ has\ emerged.\ On\ the\ fringes\ of\ known\ space,\ something\ is\ silently\ abducting\ entire\ human\ colonies.=
+Recruit.\ Explore.\ Control.Two\ years\ after\ Commander\ Shepard\ repelled\ invading\ Reapers\ bent\ on\ the\ destruction\ of\ organic\ life,\ a\ mysterious\ new\ enemy\ has\ emerged.\ On\ the\ fringes\ of\ known\ space,\ something\ is\ silently\ abducting\ entire\ human\ colonies.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Red Trigger/application.js:1
-!Red\ Trigger=
+Red\ Trigger=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Red Trigger/application.js:2
-!Red\ Trigger\ is\ a\ First\ Person\ Shooter\ (FPS)\ Puzzle\ game.\ Can\ you\ infiltrate\ and\ corrupt\ the\ system?=
+Red\ Trigger\ is\ a\ First\ Person\ Shooter\ (FPS)\ Puzzle\ game.\ Can\ you\ infiltrate\ and\ corrupt\ the\ system?=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/xact/script.js:32
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/xact/script.js:33
-!Registering\ {0}\ ...=
+Registering\ {0}\ ...=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Wine Registry Editor/script.js:1
-!Registry\ Editor=
+Registry\ Editor=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Black Mesa/application.js:2
-!Relive\ Half-Life\ in\ this\ highly\ acclaimed,\ fan-made\ recreation=
+Relive\ Half-Life\ in\ this\ highly\ acclaimed,\ fan-made\ recreation=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Repair Wine Prefix/script.js:1
-!Repair\ virtual\ drive=
+Repair\ virtual\ drive=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Resident Evil 3/application.js:1
-!Resident\ Evil\ 3=
+Resident\ Evil\ 3=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Resident Evil 3/application.js:2
-!Resident\ Evil\ 3\:\ Nemesis,\ known\ in\ Japan\ as\ Biohazard\ 3\:\ Last\ Escape\ (\u30d0\u30a4\u30aa\u30cf\u30b6\u30fc\u30c93\u3000\u30e9\u30b9\u30c8\u30a8\u30b9\u30b1\u30fc\u30d7),\ is\ a\ survival\ horror\ video\ game\ and\ the\ sequel\ to\ Resident\ Evil\ 2,\ developed\ and\ published\ by\ Capcom.\ The\ game\ was\ released\ for\ the\ PlayStation,\ and\ was\ subsequently\ ported\ to\ the\ Dreamcast,\ Microsoft\ Windows\ and\ Nintendo\ GameCube.\ A\ Windows\ PC\ version\ was\ released\ first\ in\ Japan\ in\ June\ 2000\ and\ later\ in\ other\ regions,\ which\ features\ enhanced\ 3D\ character\ model\ graphics\ and\ higher\ resolutions.=
+Resident\ Evil\ 3\:\ Nemesis,\ known\ in\ Japan\ as\ Biohazard\ 3\:\ Last\ Escape\ (\u30d0\u30a4\u30aa\u30cf\u30b6\u30fc\u30c93\u3000\u30e9\u30b9\u30c8\u30a8\u30b9\u30b1\u30fc\u30d7),\ is\ a\ survival\ horror\ video\ game\ and\ the\ sequel\ to\ Resident\ Evil\ 2,\ developed\ and\ published\ by\ Capcom.\ The\ game\ was\ released\ for\ the\ PlayStation,\ and\ was\ subsequently\ ported\ to\ the\ Dreamcast,\ Microsoft\ Windows\ and\ Nintendo\ GameCube.\ A\ Windows\ PC\ version\ was\ released\ first\ in\ Japan\ in\ June\ 2000\ and\ later\ in\ other\ regions,\ which\ features\ enhanced\ 3D\ character\ model\ graphics\ and\ higher\ resolutions.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/TRON RUNr/application.js:2
-!Return\ to\ the\ world\ of\ TRON\ with\ TRON\ RUN/r,\ a\ new\ lightning\ fast,\ action-adventure\ runner\ with\ a\ twist\!\ Hone\ your\ DISC\ and\ CYCLE\ skills,\ then\ challenge\ the\ grueling\ STREAM\ program\ that\ throws\ endless\ combinations\ of\ modes\ and\ levels\ at\ you\ until\ you\ crash\ \u2013\ how\ long\ can\ you\ survive?=
+Return\ to\ the\ world\ of\ TRON\ with\ TRON\ RUN/r,\ a\ new\ lightning\ fast,\ action-adventure\ runner\ with\ a\ twist\!\ Hone\ your\ DISC\ and\ CYCLE\ skills,\ then\ challenge\ the\ grueling\ STREAM\ program\ that\ throws\ endless\ combinations\ of\ modes\ and\ levels\ at\ you\ until\ you\ crash\ \u2013\ how\ long\ can\ you\ survive?=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Audiosurf/application.js:2
-!Ride\ your\ music.\ Audiosurf\ is\ a\ music-adapting\ puzzle\ racer\ where\ you\ use\ your\ own\ music\ to\ create\ your\ own\ experience.\ The\ shape,\ the\ speed,\ and\ the\ mood\ of\ each\ ride\ is\ determined\ by\ the\ song\ you\ choose.=
+Ride\ your\ music.\ Audiosurf\ is\ a\ music-adapting\ puzzle\ racer\ where\ you\ use\ your\ own\ music\ to\ create\ your\ own\ experience.\ The\ shape,\ the\ speed,\ and\ the\ mood\ of\ each\ ride\ is\ determined\ by\ the\ song\ you\ choose.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Road Rash/application.js:1
-!Road\ Rash=
+Road\ Rash=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rocksmith 2014/application.js:1
-!Rocksmith\u00ae\ 2014=
+Rocksmith\u00ae\ 2014=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rocksmith/application.js:2
-!Rocksmith\u2019s\ innovative\ game\ design\ makes\ playing\ music\ visually\ intuitive\ and\ will\ engage\ experienced\ musicians\ as\ well\ as\ those\ who\ have\ never\ picked\ up\ a\ guitar\ in\ their\ lives.=
+Rocksmith\u2019s\ innovative\ game\ design\ makes\ playing\ music\ visually\ intuitive\ and\ will\ engage\ experienced\ musicians\ as\ well\ as\ those\ who\ have\ never\ picked\ up\ a\ guitar\ in\ their\ lives.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rocksmith/application.js:1
-!Rocksmith\u2122=
+Rocksmith\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Super Blue Boy Planet/application.js:2
-!SBBP\ is\ a\ 2D\ platformer\ with\ pixel\ graphics.\ Blue\ boy\u2019s\ girlfriend\ is\ kidnapped\ by\ aliens\ so\ he\ goes\ through\ 21\ levels\ to\ save\ her\ and\ he\ also\ fight\ bosses\ along\ the\ way.=
+SBBP\ is\ a\ 2D\ platformer\ with\ pixel\ graphics.\ Blue\ boy\u2019s\ girlfriend\ is\ kidnapped\ by\ aliens\ so\ he\ goes\ through\ 21\ levels\ to\ save\ her\ and\ he\ also\ fight\ bosses\ along\ the\ way.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Battlefront II/application.js:1
-!STAR\ WARS\u2122\ Battlefront\u2122\ II=
+STAR\ WARS\u2122\ Battlefront\u2122\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS - Empire at War - Gold Pack/application.js:1
-!STAR\ WARS\u2122\ Empire\ at\ War\:\ Gold\ Pack=
+STAR\ WARS\u2122\ Empire\ at\ War\:\ Gold\ Pack=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight - Jedi Academy/application.js:1
-!STAR\ WARS\u2122\ Jedi\ Knight\ -\ Jedi\ Academy\u2122=
+STAR\ WARS\u2122\ Jedi\ Knight\ -\ Jedi\ Academy\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight - Mysteries of the Sith/application.js:1
-!STAR\ WARS\u2122\ Jedi\ Knight\ -\ Mysteries\ of\ the\ Sith\u2122=
+STAR\ WARS\u2122\ Jedi\ Knight\ -\ Mysteries\ of\ the\ Sith\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight II - Jedi Outcast/application.js:1
-!STAR\ WARS\u2122\ Jedi\ Knight\ II\ -\ Jedi\ Outcast\u2122=
+STAR\ WARS\u2122\ Jedi\ Knight\ II\ -\ Jedi\ Outcast\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight: Dark Forces II/application.js:1
-!STAR\ WARS\u2122\ Jedi\ Knight\:\ Dark\ Forces\ II=
+STAR\ WARS\u2122\ Jedi\ Knight\:\ Dark\ Forces\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS: Dark Forces/application.js:1
-!STAR\ WARS\u2122\:\ Dark\ Forces=
+STAR\ WARS\u2122\:\ Dark\ Forces=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS: The Old Republic/application.js:1
-!STAR\ WARS\u2122\:\ The\ Old\ Republic=
+STAR\ WARS\u2122\:\ The\ Old\ Republic=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Science/category.js:1
-!Science=
+Science=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Scribblenauts Unlimited/application.js:1
-!Scribblenauts\ Unlimited=
+Scribblenauts\ Unlimited=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Tom Clancy's Rainbow Six 3 : Raven Shield/Local (1.0->1.6)/script.js:13
-!Select\ your\ region\ for\ the\ patch\ (1.0\ to\ 1.60).=
+Select\ your\ region\ for\ the\ patch\ (1.0\ to\ 1.60).=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/League of Legends/Online/script.js:28
-!Select\ your\ region\:=
+Select\ your\ region\:=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Earth Eternal - Valkal's Shadow/application.js:2
-!Set\ in\ a\ world\ where\ humans\ are\ long\ gone,\ and\ beasts\ reign\ supreme,\ Earth\ Eternal\ -\ Valkal's\ Shadow\ is\ a\ fan-run\ continuation\ of\ Earth\ Eternal,\ an\ abandoned\ MMORPG\ by\ Sparkplay\ Media.\ Valkal's\ Shadow\ is\ based\ off\ of\ version\ 0.8.6,\ but\ with\ lots\ of\ new\ content\ and\ features\ added,\ including\ 2\ new\ regions,\ many\ new\ dungeons\ and\ countless\ new\ quests.=
+Set\ in\ a\ world\ where\ humans\ are\ long\ gone,\ and\ beasts\ reign\ supreme,\ Earth\ Eternal\ -\ Valkal's\ Shadow\ is\ a\ fan-run\ continuation\ of\ Earth\ Eternal,\ an\ abandoned\ MMORPG\ by\ Sparkplay\ Media.\ Valkal's\ Shadow\ is\ based\ off\ of\ version\ 0.8.6,\ but\ with\ lots\ of\ new\ content\ and\ features\ added,\ including\ 2\ new\ regions,\ many\ new\ dungeons\ and\ countless\ new\ quests.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hearthstone/application.js:2
-!Sheathe\ your\ sword,\ draw\ your\ deck,\ and\ get\ ready\ for\ Hearthstone\ -\ the\ fast-paced\ strategy\ card\ game\ that's\ easy\ to\ learn\ and\ massively\ fun.\ Start\ a\ free\ game\ and\ play\ your\ cards\ to\ sling\ spells,\ summon\ creatures,\ and\ command\ the\ heroes\ of\ Warcraft\ in\ duels\ of\ epic\ strategy.=
+Sheathe\ your\ sword,\ draw\ your\ deck,\ and\ get\ ready\ for\ Hearthstone\ -\ the\ fast-paced\ strategy\ card\ game\ that's\ easy\ to\ learn\ and\ massively\ fun.\ Start\ a\ free\ game\ and\ play\ your\ cards\ to\ sling\ spells,\ summon\ creatures,\ and\ command\ the\ heroes\ of\ Warcraft\ in\ duels\ of\ epic\ strategy.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Shortcuts/Reader/script.js:1
-!Shortcut\ Reader=
+Shortcut\ Reader=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Shortcuts/application.js:2
-!Shortcuts\ for\ Wine.=
+Shortcuts\ for\ Wine.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Shower With Your Dad Simulator 2015: Do You Still Shower With Your Dad/application.js:1
-!Shower\ With\ Your\ Dad\ Simulator\ 2015\:\ Do\ You\ Still\ Shower\ With\ Your\ Dad=
+Shower\ With\ Your\ Dad\ Simulator\ 2015\:\ Do\ You\ Still\ Shower\ With\ Your\ Dad=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/DC Universe Online/application.js:2
-!Sony's\ new\ MMORPG\ based\ on\ the\ DC\ universe.\ Be\ a\ hero\ or\ villain\ in\ 2\ humongous\ cities.=
+Sony's\ new\ MMORPG\ based\ on\ the\ DC\ universe.\ Be\ a\ hero\ or\ villain\ in\ 2\ humongous\ cities.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/Soundplant/application.js:1
-!Soundplant=
+Soundplant=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Accessories/Soundplant/application.js:2
-!Soundplant\ turns\ your\ computer\ keyboard\ into\ a\ versatile,\ low\ latency\ sound\ trigger\ and\ playable\ instrument.<br><br>Via\ drag\ &\ drop,\ easily\ assign\ sound\ files\ of\ any\ format\ and\ length\ onto\ 72\ keyboard\ keys,\ creating\ custom\ soundboards\ that\ put\ hours\ of\ instantly-playing\ audio\ at\ your\ fingertips\ with\ no\ extra\ hardware\ needed.<br><br>Soundplant\ is\ used\ for\ live\ music\ and\ sound\ effects,\ as\ a\ drum\ pad,\ as\ a\ unique\ electronic\ instrument,\ as\ an\ educational\ aid,\ and\ just\ for\ fun\ -\ in\ radio,\ television,\ theater,\ podcasting,\ presentations,\ studios,\ stadiums,\ classrooms,\ clubs,\ museums,\ and\ churches\ -\ by\ DJs,\ musicians,\ engineers,\ sound\ designers,\ composers,\ artists,\ teachers,\ magicians,\ puppeteers,\ comedians,\ public\ speakers,\ gamers,\ and\ more.<br><br>\ N.B.\:\ Free\ version\ has\ some\ features\ unavailable,\ see\ http\://soundplant.org/support.htm/=
+Soundplant\ turns\ your\ computer\ keyboard\ into\ a\ versatile,\ low\ latency\ sound\ trigger\ and\ playable\ instrument.<br><br>Via\ drag\ &\ drop,\ easily\ assign\ sound\ files\ of\ any\ format\ and\ length\ onto\ 72\ keyboard\ keys,\ creating\ custom\ soundboards\ that\ put\ hours\ of\ instantly-playing\ audio\ at\ your\ fingertips\ with\ no\ extra\ hardware\ needed.<br><br>Soundplant\ is\ used\ for\ live\ music\ and\ sound\ effects,\ as\ a\ drum\ pad,\ as\ a\ unique\ electronic\ instrument,\ as\ an\ educational\ aid,\ and\ just\ for\ fun\ -\ in\ radio,\ television,\ theater,\ podcasting,\ presentations,\ studios,\ stadiums,\ classrooms,\ clubs,\ museums,\ and\ churches\ -\ by\ DJs,\ musicians,\ engineers,\ sound\ designers,\ composers,\ artists,\ teachers,\ magicians,\ puppeteers,\ comedians,\ public\ speakers,\ gamers,\ and\ more.<br><br>\ N.B.\:\ Free\ version\ has\ some\ features\ unavailable,\ see\ http\://soundplant.org/support.htm/=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Star Craft II/application.js:1
-!Star\ Craft\ II=
+Star\ Craft\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Star Trek Online/application.js:1
-!Star\ Trek\ Online=
+Star\ Trek\ Online=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Star Craft II/application.js:2
-!StarCraft\ II\:\ Wings\ of\ Liberty\ is\ a\ military\ science\ fiction\ real-time\ strategy\ video\ game\ developed\ and\ published\ by\ Blizzard\ Entertainment.=
+StarCraft\ II\:\ Wings\ of\ Liberty\ is\ a\ military\ science\ fiction\ real-time\ strategy\ video\ game\ developed\ and\ published\ by\ Blizzard\ Entertainment.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Hexcells Infinite/Steam/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS: Dark Forces/Steam/script.js:1
@@ -1079,7 +1079,7 @@
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BioShock/Steam/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Total War Rome II/Steam/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Underworld/Steam/script.js:1
-!Steam=
+Steam=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rayman Legends/Steam (Demo)/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis IV/Steam (Demo)/script.js:1
@@ -1107,206 +1107,206 @@
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Crew/Steam (Demo)/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BioShock/Steam (Demo)/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Underworld/Steam (Demo)/script.js:1
-!Steam\ (Demo)=
+Steam\ (Demo)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls IV: Oblivion/Steam/script.js:1
-!Steam\ (GOTY)=
+Steam\ (GOTY)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Rainbow Six 3 : Raven Shield/Steam (Gold)/script.js:1
-!Steam\ (Gold)=
+Steam\ (Gold)=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Steam Script/script.js:1
-!Steam\ Script=
+Steam\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Steam/application.js:2
-!Steam\ is\ a\ digital\ distribution\ platform\ developed\ by\ Valve\ Corporation,\ which\ offers\ digital\ rights\ management\ (DRM),\ multiplayer\ gaming,\ video\ streaming\ and\ social\ networking\ services.=
+Steam\ is\ a\ digital\ distribution\ platform\ developed\ by\ Valve\ Corporation,\ which\ offers\ digital\ rights\ management\ (DRM),\ multiplayer\ gaming,\ video\ streaming\ and\ social\ networking\ services.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Styx: Shards of Darkness/application.js:2
-!Styx\ returns\ in\ a\ new\ stealth\ adventure\!\ Explore\ and\ master\ huge\ open\ environments,\ sneak\ past\ or\ assassinate\ new\ enemies\ and\ bosses,\ and\ experiment\ with\ the\ new\ array\ of\ lethal\ abilities\ and\ weapons\ in\ our\ goblin\ assassin's\ arsenal.=
+Styx\ returns\ in\ a\ new\ stealth\ adventure\!\ Explore\ and\ master\ huge\ open\ environments,\ sneak\ past\ or\ assassinate\ new\ enemies\ and\ bosses,\ and\ experiment\ with\ the\ new\ array\ of\ lethal\ abilities\ and\ weapons\ in\ our\ goblin\ assassin's\ arsenal.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Styx: Shards of Darkness/application.js:1
-!Styx\:\ Shards\ of\ Darkness=
+Styx\:\ Shards\ of\ Darkness=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Subnautica/application.js:1
-!Subnautica=
+Subnautica=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Subnautica/application.js:2
-!Subnautica\ is\ a\ game\ about\ exploration\ and\ adventure\ set\ in\ an\ underwater\ world.\ After\ an\ emergency\ landing\ on\ a\ foreign\ water\ planet\ you\ can\ only\ look\ in\ the\ depths.\ Discover\ seaweed\ forests\ and\ grass\ plateaus,\ reefs\ and\ labyrinths\ of\ underwater\ caves,\ but\ remember\ the\ ever-diminished\ oxygen.\ Water\ is\ swarming\ with\ life\:\ some\ creatures\ are\ useful,\ but\ a\ large\ part\ is\ dangerous.\ When\ you\ wake\ up\ in\ a\ life\ capsule,\ you\ fight\ with\ time\ -\ you\ need\ to\ find\ drinking\ water,\ food,\ and\ develop\ equipment\ that\ will\ be\ useful\ during\ exploration.\ Collect\ resources\ from\ the\ ocean\ around\ you.\ Create\ knives,\ lighting,\ diving\ equipment,\ and\ build\ small\ submarines.\ The\ ocean\ is\ full\ of\ life\:\ use\ the\ ecosystem\ to\ your\ advantage.\ Lure\ and\ outwit\ the\ dangerous\ creature\ with\ a\ fresh\ fish,\ or\ just\ swim\ as\ fast\ as\ you\ can\ to\ avoid\ the\ jaws\ of\ omnipresent\ predators.\ Cave\ systems\ extend\ below\ the\ bottom\ of\ the\ ocean\ -\ from\ dark,\ claustrophobic\ passages\ to\ caves\ illuminated\ by\ bioluminescent\ life\ forms.\ Explore\ the\ world\ below\ the\ bottom\ of\ the\ ocean,\ but\ watch\ out\ for\ oxygen\ levels\ and\ avoid\ the\ dangers\ lurking\ in\ the\ dark.=
+Subnautica\ is\ a\ game\ about\ exploration\ and\ adventure\ set\ in\ an\ underwater\ world.\ After\ an\ emergency\ landing\ on\ a\ foreign\ water\ planet\ you\ can\ only\ look\ in\ the\ depths.\ Discover\ seaweed\ forests\ and\ grass\ plateaus,\ reefs\ and\ labyrinths\ of\ underwater\ caves,\ but\ remember\ the\ ever-diminished\ oxygen.\ Water\ is\ swarming\ with\ life\:\ some\ creatures\ are\ useful,\ but\ a\ large\ part\ is\ dangerous.\ When\ you\ wake\ up\ in\ a\ life\ capsule,\ you\ fight\ with\ time\ -\ you\ need\ to\ find\ drinking\ water,\ food,\ and\ develop\ equipment\ that\ will\ be\ useful\ during\ exploration.\ Collect\ resources\ from\ the\ ocean\ around\ you.\ Create\ knives,\ lighting,\ diving\ equipment,\ and\ build\ small\ submarines.\ The\ ocean\ is\ full\ of\ life\:\ use\ the\ ecosystem\ to\ your\ advantage.\ Lure\ and\ outwit\ the\ dangerous\ creature\ with\ a\ fresh\ fish,\ or\ just\ swim\ as\ fast\ as\ you\ can\ to\ avoid\ the\ jaws\ of\ omnipresent\ predators.\ Cave\ systems\ extend\ below\ the\ bottom\ of\ the\ ocean\ -\ from\ dark,\ claustrophobic\ passages\ to\ caves\ illuminated\ by\ bioluminescent\ life\ forms.\ Explore\ the\ world\ below\ the\ bottom\ of\ the\ ocean,\ but\ watch\ out\ for\ oxygen\ levels\ and\ avoid\ the\ dangers\ lurking\ in\ the\ dark.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Super Blue Boy Planet/application.js:1
-!Super\ Blue\ Boy\ Planet=
+Super\ Blue\ Boy\ Planet=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/TRON RUNr/application.js:1
-!TRON\ RUN/r=
+TRON\ RUN/r=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/Tahoma/script.js:1
-!Tahoma=
+Tahoma=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Medieval II: Total War/application.js:2
-!Take\ command\ of\ your\ army\ and\ expand\ your\ reign\ in\ Medieval\ II\ -\ the\ fourth\ installment\ of\ the\ award-winning\ Total\ War\ series\ of\ strategy\ games.\ Direct\ massive\ battles\ featuring\ up\ to\ 10,000\ bloodthirsty\ troops\ on\ epic\ 3D\ battlefields,\ while\ presiding\ over\ some\ of\ the\ greatest\ Medieval\ nations\ of\ the\ Western\ and\ Middle\ Eastern\ world.\ Spanning\ the\ most\ turbulent\ era\ in\ Western\ history,\ your\ quest\ for\ territory\ and\ power\ takes\ you\ through\ Europe,\ Africa,\ and\ the\ Middle\ East,\ and\ even\ onto\ the\ shores\ of\ the\ New\ World.<br>You'll\ manage\ your\ empire\ with\ an\ iron\ fist,\ handling\ everything\ from\ building\ and\ improving\ cities\ to\ recruiting\ and\ training\ armies.\ Wield\ diplomacy\ to\ manipulate\ allies\ and\ enemies,\ outsmart\ the\ dreaded\ Inquisition,\ and\ influence\ the\ Pope.\ Lead\ the\ fight\ in\ the\ Crusades\ and\ bring\ victory\ to\ Islam\ or\ Christianity\ in\ the\ Holy\ War.\ Rewrite\ history\ and\ conquer\ the\ world.\ This\ is\ Total\ War\!=
+Take\ command\ of\ your\ army\ and\ expand\ your\ reign\ in\ Medieval\ II\ -\ the\ fourth\ installment\ of\ the\ award-winning\ Total\ War\ series\ of\ strategy\ games.\ Direct\ massive\ battles\ featuring\ up\ to\ 10,000\ bloodthirsty\ troops\ on\ epic\ 3D\ battlefields,\ while\ presiding\ over\ some\ of\ the\ greatest\ Medieval\ nations\ of\ the\ Western\ and\ Middle\ Eastern\ world.\ Spanning\ the\ most\ turbulent\ era\ in\ Western\ history,\ your\ quest\ for\ territory\ and\ power\ takes\ you\ through\ Europe,\ Africa,\ and\ the\ Middle\ East,\ and\ even\ onto\ the\ shores\ of\ the\ New\ World.<br>You'll\ manage\ your\ empire\ with\ an\ iron\ fist,\ handling\ everything\ from\ building\ and\ improving\ cities\ to\ recruiting\ and\ training\ armies.\ Wield\ diplomacy\ to\ manipulate\ allies\ and\ enemies,\ outsmart\ the\ dreaded\ Inquisition,\ and\ influence\ the\ Pope.\ Lead\ the\ fight\ in\ the\ Crusades\ and\ bring\ victory\ to\ Islam\ or\ Christianity\ in\ the\ Holy\ War.\ Rewrite\ history\ and\ conquer\ the\ world.\ This\ is\ Total\ War\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Elite:Dangerous/application.js:2
-!Take\ control\ of\ your\ own\ starship\ in\ a\ cutthroat\ galaxy.\ Elite\ Dangerous\ brings\ gaming\u2019s\ original\ open\ world\ adventure\ into\ the\ modern\ generation\ with\ a\ connected\ galaxy,\ evolving\ narrative\ and\ the\ entirety\ of\ the\ Milky\ Way\ re-created\ at\ its\ full\ galactic\ proportions.<br><br>Elite\ Dangerous\ is\ the\ definitive\ massively\ multiplayer\ space\ epic,\ bringing\ gaming\u2019s\ original\ open\ world\ adventure\ to\ the\ modern\ generation\ with\ a\ connected\ galaxy,\ evolving\ narrative\ and\ the\ entirety\ of\ the\ Milky\ Way\ re-created\ at\ its\ full\ galactic\ proportions.=
+Take\ control\ of\ your\ own\ starship\ in\ a\ cutthroat\ galaxy.\ Elite\ Dangerous\ brings\ gaming\u2019s\ original\ open\ world\ adventure\ into\ the\ modern\ generation\ with\ a\ connected\ galaxy,\ evolving\ narrative\ and\ the\ entirety\ of\ the\ Milky\ Way\ re-created\ at\ its\ full\ galactic\ proportions.<br><br>Elite\ Dangerous\ is\ the\ definitive\ massively\ multiplayer\ space\ epic,\ bringing\ gaming\u2019s\ original\ open\ world\ adventure\ to\ the\ modern\ generation\ with\ a\ connected\ galaxy,\ evolving\ narrative\ and\ the\ entirety\ of\ the\ Milky\ Way\ re-created\ at\ its\ full\ galactic\ proportions.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/PAYDAY The Heist/application.js:2
-!Take\ on\ the\ role\ of\ a\ hardened\ career\ criminal\ executing\ intense,\ dynamic\ heists\ in\ constant\ pursuit\ of\ the\ next\ \u201cbig\ score\u201d=
+Take\ on\ the\ role\ of\ a\ hardened\ career\ criminal\ executing\ intense,\ dynamic\ heists\ in\ constant\ pursuit\ of\ the\ next\ \u201cbig\ score\u201d=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Wine Task Manager/script.js:1
-!Task\ manager=
+Task\ manager=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/TeamSpeak 3/application.js:1
-!TeamSpeak\ 3=
+TeamSpeak\ 3=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/TeamSpeak 3/application.js:2
-!TeamSpeak\ 3\ offers\ the\ ideal\ voice\ communication\ tool\ for\ online\ gaming,\ education\ and\ training,\ internal\ business\ communication,\ and\ staying\ in\ touch\ with\ friends\ and\ family.=
+TeamSpeak\ 3\ offers\ the\ ideal\ voice\ communication\ tool\ for\ online\ gaming,\ education\ and\ training,\ internal\ business\ communication,\ and\ staying\ in\ touch\ with\ friends\ and\ family.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed III/application.js:2
-!The\ American\ Colonies,\ 1775.\ It\u2019s\ a\ time\ of\ civil\ unrest\ and\ political\ upheaval\ in\ the\ Americas.\ As\ a\ Native\ American\ assassin\ fights\ to\ protect\ his\ land\ and\ his\ people,\ he\ will\ ignite\ the\ flames\ of\ a\ young\ nation\u2019s\ revolution.<br>Assassin\u2019s\ Creed\u00ae\ III\ takes\ you\ back\ to\ the\ American\ Revolutionary\ War,\ but\ not\ the\ one\ you\u2019ve\ read\ about\ in\ history\ books...=
+The\ American\ Colonies,\ 1775.\ It\u2019s\ a\ time\ of\ civil\ unrest\ and\ political\ upheaval\ in\ the\ Americas.\ As\ a\ Native\ American\ assassin\ fights\ to\ protect\ his\ land\ and\ his\ people,\ he\ will\ ignite\ the\ flames\ of\ a\ young\ nation\u2019s\ revolution.<br>Assassin\u2019s\ Creed\u00ae\ III\ takes\ you\ back\ to\ the\ American\ Revolutionary\ War,\ but\ not\ the\ one\ you\u2019ve\ read\ about\ in\ history\ books...=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Blizzard app/application.js:2
-!The\ Blizzard\ desktop\ app\ is\ designed\ to\ improve\ your\ gaming\ experience.\ It\u2019ll\ streamline\ your\ login\ and\ make\ it\ even\ easier\ to\ keep\ up\ with\ your\ friends\!=
+The\ Blizzard\ desktop\ app\ is\ designed\ to\ improve\ your\ gaming\ experience.\ It\u2019ll\ streamline\ your\ login\ and\ make\ it\ even\ easier\ to\ keep\ up\ with\ your\ friends\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Crew/application.js:1
-!The\ Crew\u2122=
+The\ Crew\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls IV: Oblivion/application.js:1
-!The\ Elder\ Scrolls\ IV\:\ Oblivion=
+The\ Elder\ Scrolls\ IV\:\ Oblivion=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls IV: Oblivion/application.js:2
-!The\ Elder\ Scrolls\ IV\:\ Oblivion\u00ae\ presents\ one\ of\ the\ best\ RPGs\ of\ all\ time\ like\ never\ before.\ Step\ inside\ the\ most\ richly\ detailed\ and\ vibrant\ game-world\ ever\ created.\ With\ a\ powerful\ combination\ of\ freeform\ gameplay\ and\ unprecedented\ graphics,\ you\ can\ unravel\ the\ main\ quest\ at\ your\ own\ pace\ or\ explore\ the\ vast\ world\ and\ find\ your\ own\ challenges.=
+The\ Elder\ Scrolls\ IV\:\ Oblivion\u00ae\ presents\ one\ of\ the\ best\ RPGs\ of\ all\ time\ like\ never\ before.\ Step\ inside\ the\ most\ richly\ detailed\ and\ vibrant\ game-world\ ever\ created.\ With\ a\ powerful\ combination\ of\ freeform\ gameplay\ and\ unprecedented\ graphics,\ you\ can\ unravel\ the\ main\ quest\ at\ your\ own\ pace\ or\ explore\ the\ vast\ world\ and\ find\ your\ own\ challenges.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls V: Skyrim/application.js:1
-!The\ Elder\ Scrolls\ V\:\ Skyrim=
+The\ Elder\ Scrolls\ V\:\ Skyrim=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/STAR WARS Jedi Knight II - Jedi Outcast/application.js:2
-!The\ Legacy\ of\ Star\ Wars\ Dark\ Forces\u2122\ and\ Star\ Wars\u00ae\ Jedi\ Knight\ lives\ on\ in\ the\ intense\ first-person\ action\ of\ Jedi\ Outcast.\ =
+The\ Legacy\ of\ Star\ Wars\ Dark\ Forces\u2122\ and\ Star\ Wars\u00ae\ Jedi\ Knight\ lives\ on\ in\ the\ intense\ first-person\ action\ of\ Jedi\ Outcast.\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/LocalInstaller/application.js:2
-!The\ Local\ Installer\ allows\ you\ to\ install\ custom\ applications\ from\ your\ local\ computer.=
+The\ Local\ Installer\ allows\ you\ to\ install\ custom\ applications\ from\ your\ local\ computer.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Custom/OnlineInstaller/application.js:2
-!The\ Online\ Installer\ allows\ you\ to\ install\ custom\ applications\ from\ the\ Internet.=
+The\ Online\ Installer\ allows\ you\ to\ install\ custom\ applications\ from\ the\ Internet.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Room/application.js:1
-!The\ Room=
+The\ Room=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Room Two/application.js:1
-!The\ Room\ Two=
+The\ Room\ Two=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Sims/application.js:1
-!The\ Sims=
+The\ Sims=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Sims/application.js:2
-!The\ Sims\ is\ a\ simulation\ game\ that\ simulates\ people.\ With\ various\ goals\ and\ objectives\ you\ control\ people\ called\ sims.\ These\ sims\ require\ the\ user\ to\ periodically\ replenish\ their\ needs,\ socialize,\ and\ buy\ new\ stuff.\ The\ game\ currently\ has\ 7\ expansion\ packs,\ Livin\ Large,\ House\ Party,\ Hot\ Date,\ Vacation,\ Superstar,\ Makin\ Magic,\ and\ Unleashed.\ =
+The\ Sims\ is\ a\ simulation\ game\ that\ simulates\ people.\ With\ various\ goals\ and\ objectives\ you\ control\ people\ called\ sims.\ These\ sims\ require\ the\ user\ to\ periodically\ replenish\ their\ needs,\ socialize,\ and\ buy\ new\ stuff.\ The\ game\ currently\ has\ 7\ expansion\ packs,\ Livin\ Large,\ House\ Party,\ Hot\ Date,\ Vacation,\ Superstar,\ Makin\ Magic,\ and\ Unleashed.\ =
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Turing Test/application.js:1
-!The\ Turing\ Test=
+The\ Turing\ Test=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Turing Test/application.js:2
-!The\ Turing\ Test\ is\ a\ challenging\ first-person\ puzzle\ game\ set\ on\ Jupiter\u2019s\ moon,\ Europa.\ You\ are\ Ava\ Turing,\ an\ engineer\ for\ the\ International\ Space\ Agency\ (ISA)\ sent\ to\ discover\ the\ cause\ behind\ the\ disappearance\ of\ the\ ground\ crew\ stationed\ there.=
+The\ Turing\ Test\ is\ a\ challenging\ first-person\ puzzle\ game\ set\ on\ Jupiter\u2019s\ moon,\ Europa.\ You\ are\ Ava\ Turing,\ an\ engineer\ for\ the\ International\ Space\ Agency\ (ISA)\ sent\ to\ discover\ the\ cause\ behind\ the\ disappearance\ of\ the\ ground\ crew\ stationed\ there.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Vanishing of Ethan Carter/application.js:1
-!The\ Vanishing\ of\ Ethan\ Carter=
+The\ Vanishing\ of\ Ethan\ Carter=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Vanishing of Ethan Carter Redux/application.js:1
-!The\ Vanishing\ of\ Ethan\ Carter\ Redux=
+The\ Vanishing\ of\ Ethan\ Carter\ Redux=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Vanishing of Ethan Carter/application.js:2
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Vanishing of Ethan Carter Redux/application.js:2
-!The\ Vanishing\ of\ Ethan\ Carter\ is\ a\ first-person\ story-driven\ mystery.=
+The\ Vanishing\ of\ Ethan\ Carter\ is\ a\ first-person\ story-driven\ mystery.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Engine/application.js:2
-!The\ Wine\ engine.=
+The\ Wine\ engine.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Witcher 3: Wild Hunt/application.js:1
-!The\ Witcher\ 3\:\ Wild\ Hunt=
+The\ Witcher\ 3\:\ Wild\ Hunt=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Witcher 3: Wild Hunt/application.js:2
-!The\ Witcher\:\ Wild\ Hunt\ is\ a\ story-driven,\ next-generation\ open\ world\ role-playing\ game\ set\ in\ a\ visually\ stunning\ fantasy\ universe\ full\ of\ meaningful\ choices\ and\ impactful\ consequences.\ In\ The\ Witcher\ you\ play\ as\ the\ professional\ monster\ hunter,\ Geralt\ of\ Rivia,\ tasked\ with\ finding\ a\ child\ of\ prophecy\ in\ a\ vast\ open\ world\ rich\ with\ merchant\ cities,\ viking\ pirate\ islands,\ dangerous\ mountain\ passes,\ and\ forgotten\ caverns\ to\ explore.=
+The\ Witcher\:\ Wild\ Hunt\ is\ a\ story-driven,\ next-generation\ open\ world\ role-playing\ game\ set\ in\ a\ visually\ stunning\ fantasy\ universe\ full\ of\ meaningful\ choices\ and\ impactful\ consequences.\ In\ The\ Witcher\ you\ play\ as\ the\ professional\ monster\ hunter,\ Geralt\ of\ Rivia,\ tasked\ with\ finding\ a\ child\ of\ prophecy\ in\ a\ vast\ open\ world\ rich\ with\ merchant\ cities,\ viking\ pirate\ islands,\ dangerous\ mountain\ passes,\ and\ forgotten\ caverns\ to\ explore.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Witness/application.js:1
-!The\ Witness=
+The\ Witness=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Shortcuts/Reader/script.js:62
-!The\ container\ {0}\ is\ no\ longer\ used.\nDo\ you\ want\ to\ delete\ it?=
+The\ container\ {0}\ is\ no\ longer\ used.\nDo\ you\ want\ to\ delete\ it?=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Europa Universalis IV/application.js:2
-!The\ empire\ building\ game\ Europa\ Universalis\ IV\ gives\ you\ control\ of\ a\ nation\ to\ guide\ through\ the\ years\ in\ order\ to\ create\ a\ dominant\ global\ empire.\ Rule\ your\ nation\ through\ the\ centuries,\ with\ unparalleled\ freedom,\ depth\ and\ historical\ accuracy.=
+The\ empire\ building\ game\ Europa\ Universalis\ IV\ gives\ you\ control\ of\ a\ nation\ to\ guide\ through\ the\ years\ in\ order\ to\ create\ a\ dominant\ global\ empire.\ Rule\ your\ nation\ through\ the\ centuries,\ with\ unparalleled\ freedom,\ depth\ and\ historical\ accuracy.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Rocksmith 2014/application.js:2
-!The\ fastest\ way\ to\ learn\ guitar\ is\ now\ better\ than\ ever.\ Join\ over\ three\ million\ people\ who\ have\ learned\ to\ play\ guitar\ with\ the\ award-winning\ Rocksmith\u00ae\ method.\ Plug\ any\ real\ guitar\ or\ bass\ with\ a\ 1/4\ inch\ jack\ directly\ into\ your\ PC\ or\ Mac\ and\ you\u2019ll\ learn\ to\ play\ in\ just\ 60\ days.=
+The\ fastest\ way\ to\ learn\ guitar\ is\ now\ better\ than\ ever.\ Join\ over\ three\ million\ people\ who\ have\ learned\ to\ play\ guitar\ with\ the\ award-winning\ Rocksmith\u00ae\ method.\ Plug\ any\ real\ guitar\ or\ bass\ with\ a\ 1/4\ inch\ jack\ directly\ into\ your\ PC\ or\ Mac\ and\ you\u2019ll\ learn\ to\ play\ in\ just\ 60\ days.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Toki Tori/application.js:2
-!The\ gameplay\ in\ Toki\ Tori\ is\ a\ blend\ of\ two\ genres.\ While\ it\ looks\ like\ a\ platform\ game,\ it's\ a\ puzzle\ game\ at\ heart.\ To\ progress\ through\ the\ game,\ the\ player\ must\ pick\ up\ each\ egg\ in\ a\ level\ using\ a\ set\ number\ of\ tools.=
+The\ gameplay\ in\ Toki\ Tori\ is\ a\ blend\ of\ two\ genres.\ While\ it\ looks\ like\ a\ platform\ game,\ it's\ a\ puzzle\ game\ at\ heart.\ To\ progress\ through\ the\ game,\ the\ player\ must\ pick\ up\ each\ egg\ in\ a\ level\ using\ a\ set\ number\ of\ tools.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Legend/application.js:2
-!The\ gaming\ world's\ sexiest\ and\ most\ intrepid\ adventurer\ makes\ her\ triumphant\ return\ in\ Lara\ Croft\ Tomb\ Raider\:\ Legend\!<br><br>Follow\ Lara\ down\ a\ path\ of\ discovery\ as\ she\ travels\ the\ globe\ to\ remote,\ exotic\ locales\ in\ search\ of\ one\ of\ history's\ greatest\ artifacts\ that\ unleash\ unwelcome\ figures\ from\ Lara's\ mysterious\ past.\ With\ guns\ blazing,\ Lara\ must\ use\ her\ athletic\ ability\ and\ intellectual\ wits\ to\ explore\ vast,\ treacherous\ tombs,\ riddled\ with\ challenging\ puzzles\ and\ deadly\ traps.\ Experience\ the\ beginning\ of\ the\ new\ Legend\ in\ the\ most\ adrenaline-fueled\ Tomb\ Raider\ adventure\ ever\!=
+The\ gaming\ world's\ sexiest\ and\ most\ intrepid\ adventurer\ makes\ her\ triumphant\ return\ in\ Lara\ Croft\ Tomb\ Raider\:\ Legend\!<br><br>Follow\ Lara\ down\ a\ path\ of\ discovery\ as\ she\ travels\ the\ globe\ to\ remote,\ exotic\ locales\ in\ search\ of\ one\ of\ history's\ greatest\ artifacts\ that\ unleash\ unwelcome\ figures\ from\ Lara's\ mysterious\ past.\ With\ guns\ blazing,\ Lara\ must\ use\ her\ athletic\ ability\ and\ intellectual\ wits\ to\ explore\ vast,\ treacherous\ tombs,\ riddled\ with\ challenging\ puzzles\ and\ deadly\ traps.\ Experience\ the\ beginning\ of\ the\ new\ Legend\ in\ the\ most\ adrenaline-fueled\ Tomb\ Raider\ adventure\ ever\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warcraft III Expansion Set/application.js:2
-!The\ war\ rages\ on.\ The\ demonic\ threat\ has\ been\ banished\ from\ the\ battle-scarred\ fields\ of\ Azeroth,\ but\ peace\ is\ still\ a\ distant\ dream.\ The\ epic\ conflict\ that\ began\ in\ Warcraft\ III\:\ Reign\ of\ Chaos\ continues\ with\ more\ units,\ more\ missions,\ and\ more\ explosive\ strategic\ combat.<br><br>This\ set\ contains\ both\ Warcraft\ III\:\ Reign\ of\ Chaos\ and\ Warcraft\ III\:\ The\ Frozen\ Throne.=
+The\ war\ rages\ on.\ The\ demonic\ threat\ has\ been\ banished\ from\ the\ battle-scarred\ fields\ of\ Azeroth,\ but\ peace\ is\ still\ a\ distant\ dream.\ The\ epic\ conflict\ that\ began\ in\ Warcraft\ III\:\ Reign\ of\ Chaos\ continues\ with\ more\ units,\ more\ missions,\ and\ more\ explosive\ strategic\ combat.<br><br>This\ set\ contains\ both\ Warcraft\ III\:\ Reign\ of\ Chaos\ and\ Warcraft\ III\:\ The\ Frozen\ Throne.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tropico 4/application.js:2
-!The\ world\ is\ changing\ and\ Tropico\ is\ moving\ with\ the\ times\ -\ geographical\ powers\ rise\ and\ fall\ and\ the\ world\ market\ is\ dominated\ by\ new\ players\ with\ new\ demands\ and\ offers\ -\ and\ you,\ as\ El\ Presidente,\ face\ a\ whole\ new\ set\ of\ challenges.\ If\ you\ are\ to\ triumph\ over\ your\ naysayers\ you\ will\ need\ to\ gain\ as\ much\ support\ from\ your\ people\ as\ possible.\ Your\ decisions\ will\ shape\ the\ future\ of\ your\ nation,\ and\ more\ importantly,\ the\ size\ of\ your\ off-shore\ bank\ account.<br><br>Tropico\ 4\ expands\ on\ the\ gameplay\ of\ the\ previous\ game\ with\ new\ political\ additions\ \u223c\ including\ more\ superpowers\ to\ negotiate\ with,\ along\ with\ the\ ability\ to\ elect\ ministers\ into\ power\ to\ help\ get\ your\ more\ controversial\ policies\ passed.\ But\ remember\ to\ keep\ your\ friends\ close\ and\ your\ enemies\ closer\ as\ everyone\ has\ an\ agenda\!\ Your\ political\ mettle\ will\ be\ thoroughly\ tested,\ as\ new\ natural\ disasters\ will\ have\ the\ populace\ clamoring\ for\ you\ and\ your\ cabinet\ to\ help\ them\ recover\ from\ some\ of\ the\ worst\ Mother\ Nature\ can\ dish\ out.<br><br>Tropico\ 4\ also\ brings\ a\ new\ level\ of\ social\ interaction\ with\ the\ addition\ of\ Facebook\ and\ Twitter\ integration.\ Post\ comments\ on\ Twitter\ direct\ from\ the\ game\ and\ have\ updates\ go\ out\ when\ you\ complete\ missions\ or\ unlock\ new\ achievements.\ You\ can\ even\ take\ screenshots\ of\ your\ burgeoning\ island\ and\ post\ your\ dream\ creation\ on\ your\ Tropico\ 4\ Facebook\ page\ and\ compare\ your\ interactive\ Dictator\ Ranking\ on\ the\ online\ leaderboards.=
+The\ world\ is\ changing\ and\ Tropico\ is\ moving\ with\ the\ times\ -\ geographical\ powers\ rise\ and\ fall\ and\ the\ world\ market\ is\ dominated\ by\ new\ players\ with\ new\ demands\ and\ offers\ -\ and\ you,\ as\ El\ Presidente,\ face\ a\ whole\ new\ set\ of\ challenges.\ If\ you\ are\ to\ triumph\ over\ your\ naysayers\ you\ will\ need\ to\ gain\ as\ much\ support\ from\ your\ people\ as\ possible.\ Your\ decisions\ will\ shape\ the\ future\ of\ your\ nation,\ and\ more\ importantly,\ the\ size\ of\ your\ off-shore\ bank\ account.<br><br>Tropico\ 4\ expands\ on\ the\ gameplay\ of\ the\ previous\ game\ with\ new\ political\ additions\ \u223c\ including\ more\ superpowers\ to\ negotiate\ with,\ along\ with\ the\ ability\ to\ elect\ ministers\ into\ power\ to\ help\ get\ your\ more\ controversial\ policies\ passed.\ But\ remember\ to\ keep\ your\ friends\ close\ and\ your\ enemies\ closer\ as\ everyone\ has\ an\ agenda\!\ Your\ political\ mettle\ will\ be\ thoroughly\ tested,\ as\ new\ natural\ disasters\ will\ have\ the\ populace\ clamoring\ for\ you\ and\ your\ cabinet\ to\ help\ them\ recover\ from\ some\ of\ the\ worst\ Mother\ Nature\ can\ dish\ out.<br><br>Tropico\ 4\ also\ brings\ a\ new\ level\ of\ social\ interaction\ with\ the\ addition\ of\ Facebook\ and\ Twitter\ integration.\ Post\ comments\ on\ Twitter\ direct\ from\ the\ game\ and\ have\ updates\ go\ out\ when\ you\ complete\ missions\ or\ unlock\ new\ achievements.\ You\ can\ even\ take\ screenshots\ of\ your\ burgeoning\ island\ and\ post\ your\ dream\ creation\ on\ your\ Tropico\ 4\ Facebook\ page\ and\ compare\ your\ interactive\ Dictator\ Ranking\ on\ the\ online\ leaderboards.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Assassin's Creed IV Black Flag/application.js:2
-!The\ year\ is\ 1715.\ Pirates\ rule\ the\ Caribbean\ and\ have\ established\ their\ own\ lawless\ Republic\ where\ corruption,\ greediness\ and\ cruelty\ are\ commonplace.Among\ these\ outlaws\ is\ a\ brash\ young\ captain\ named\ Edward\ Kenway.=
+The\ year\ is\ 1715.\ Pirates\ rule\ the\ Caribbean\ and\ have\ established\ their\ own\ lawless\ Republic\ where\ corruption,\ greediness\ and\ cruelty\ are\ commonplace.Among\ these\ outlaws\ is\ a\ brash\ young\ captain\ named\ Edward\ Kenway.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Worms Armageddon/application.js:2
-!Those\ intrepid\ invertebrates\ return\ with\ a\ vengeance\ in\ the\ much-loved\ Worms\u2122\ Armageddon.\ It\u2019s\ a\ whole\ new\ can\ of\ worms\!\ It\u2019s\ hilarious\ fun\ that\ you\ can\ enjoy\ on\ your\ own\ or\ with\ all\ your\ friends.=
+Those\ intrepid\ invertebrates\ return\ with\ a\ vengeance\ in\ the\ much-loved\ Worms\u2122\ Armageddon.\ It\u2019s\ a\ whole\ new\ can\ of\ worms\!\ It\u2019s\ hilarious\ fun\ that\ you\ can\ enjoy\ on\ your\ own\ or\ with\ all\ your\ friends.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Toki Tori/application.js:1
-!Toki\ Tori=
+Toki\ Tori=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Rainbow Six 3 : Raven Shield/application.js:1
-!Tom\ Clancy's\ Rainbow\ Six\ 3\ \:\ Raven\ Shield=
+Tom\ Clancy's\ Rainbow\ Six\ 3\ \:\ Raven\ Shield=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Splinter Cell/application.js:1
-!Tom\ Clancy's\ Splinter\ Cell\u00ae=
+Tom\ Clancy's\ Splinter\ Cell\u00ae=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's The Division/application.js:1
-!Tom\ Clancy\u2019s\ The\ Division\u2122=
+Tom\ Clancy\u2019s\ The\ Division\u2122=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Anniversary/application.js:1
-!Tomb\ Raider\:\ Anniversary=
+Tomb\ Raider\:\ Anniversary=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Anniversary/application.js:2
-!Tomb\ Raider\:\ Anniversary\ retraces\ Lara\ Croft's\ original\ genre-defining\ adventure\ globe-trotting\ 3rd\ person\ action-adventure\ in\ pursuit\ of\ the\ legendary\ Scion\ artifact.\ Using\ an\ enhanced\ 'Tomb\ Raider\:\ Legend'\ game\ engine,\ the\ graphics,\ technology\ and\ physics\ bring\ Lara's\ adventure\ and\ pursuit\ of\ a\ mystical\ artifact\ known\ only\ as\ the\ Scion\ right\ up\ to\ today's\ technology\ standards\ and\ offers\ gamers\ a\ completely\ new\ gameplay\ experience.\ Re-imagined,\ Anniversary\ delivers\ a\ dynamic\ fluidly\ and\ fast\ Lara\ Croft,\ massive\ environments\ of\ stunning\ visuals,\ intense\ combat\ and\ game\ pacing,\ and\ an\ enhanced\ and\ clarified\ original\ story.=
+Tomb\ Raider\:\ Anniversary\ retraces\ Lara\ Croft's\ original\ genre-defining\ adventure\ globe-trotting\ 3rd\ person\ action-adventure\ in\ pursuit\ of\ the\ legendary\ Scion\ artifact.\ Using\ an\ enhanced\ 'Tomb\ Raider\:\ Legend'\ game\ engine,\ the\ graphics,\ technology\ and\ physics\ bring\ Lara's\ adventure\ and\ pursuit\ of\ a\ mystical\ artifact\ known\ only\ as\ the\ Scion\ right\ up\ to\ today's\ technology\ standards\ and\ offers\ gamers\ a\ completely\ new\ gameplay\ experience.\ Re-imagined,\ Anniversary\ delivers\ a\ dynamic\ fluidly\ and\ fast\ Lara\ Croft,\ massive\ environments\ of\ stunning\ visuals,\ intense\ combat\ and\ game\ pacing,\ and\ an\ enhanced\ and\ clarified\ original\ story.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Legend/application.js:1
-!Tomb\ Raider\:\ Legend=
+Tomb\ Raider\:\ Legend=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider: The Dagger Of Xian/application.js:1
-!Tomb\ Raider\:\ The\ Dagger\ Of\ Xian=
+Tomb\ Raider\:\ The\ Dagger\ Of\ Xian=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Underworld/application.js:1
-!Tomb\ Raider\:\ Underworld=
+Tomb\ Raider\:\ Underworld=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tomb Raider Underworld/application.js:2
-!Tomb\ Raider\:\ Underworld\ represents\ a\ new\ advancement\ in\ exploration-based\ gameplay.\ As\ fearless\ adventurer\ Lara\ Croft\ explore\ exotic\ locations\ around\ the\ world,\ each\ designed\ with\ an\ incredible\ attention\ to\ detail\ resulting\ in\ breathtaking\ high-definition\ visual\ fidelity\ that\ creates\ a\ truly\ believable\ world\ and\ delivers\ a\ new\ level\ of\ challenge\ and\ choice.=
+Tomb\ Raider\:\ Underworld\ represents\ a\ new\ advancement\ in\ exploration-based\ gameplay.\ As\ fearless\ adventurer\ Lara\ Croft\ explore\ exotic\ locations\ around\ the\ world,\ each\ designed\ with\ an\ incredible\ attention\ to\ detail\ resulting\ in\ breathtaking\ high-definition\ visual\ fidelity\ that\ creates\ a\ truly\ believable\ world\ and\ delivers\ a\ new\ level\ of\ challenge\ and\ choice.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/application.js:2
-!Tools\ for\ Wine.=
+Tools\ for\ Wine.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Total War Rome II/application.js:1
-!Total\ War\:\ ROME\ II=
+Total\ War\:\ ROME\ II=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Trackmania Turbo/application.js:2
-!Trackmania\ offers\ you\ the\ ultimate\ arcade\ racing\ universe\ where\ everything\ is\ about\ reaching\ the\ perfect\ racing\ time.\ Test\ your\ skills\ in\ over\ 200\ tracks,\ experience\ immediate\ fun\ by\ challenging\ your\ friends\ at\ home\ (offline\ splitscreen)\ or\ online.=
+Trackmania\ offers\ you\ the\ ultimate\ arcade\ racing\ universe\ where\ everything\ is\ about\ reaching\ the\ perfect\ racing\ time.\ Test\ your\ skills\ in\ over\ 200\ tracks,\ experience\ immediate\ fun\ by\ challenging\ your\ friends\ at\ home\ (offline\ splitscreen)\ or\ online.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Trackmania Turbo/application.js:1
-!Trackmania\u00ae\ Turbo=
+Trackmania\u00ae\ Turbo=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tropico 3/application.js:1
-!Tropico\ 3=
+Tropico\ 3=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tropico 4/application.js:1
-!Tropico\ 4=
+Tropico\ 4=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Unholy Heights/application.js:1
-!Unholy\ Heights=
+Unholy\ Heights=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Room Two/application.js:2
-!Unique\ events\ transport\ you\ to\ the\ halls\ of\ a\ long-forgotten\ crypt.\ The\ only\ means\ of\ escape\ lies\ locked\ within\ a\ stone\ pedestal,\ along\ with\ a\ note\ from\ your\ mysterious\ ally.\ His\ words\ promise\ assistance,\ but\ only\ serve\ to\ entice\ you\ into\ a\ compelling\ world\ of\ mystery\ and\ exploration.=
+Unique\ events\ transport\ you\ to\ the\ halls\ of\ a\ long-forgotten\ crypt.\ The\ only\ means\ of\ escape\ lies\ locked\ within\ a\ stone\ pedestal,\ along\ with\ a\ note\ from\ your\ mysterious\ ally.\ His\ words\ promise\ assistance,\ but\ only\ serve\ to\ entice\ you\ into\ a\ compelling\ world\ of\ mystery\ and\ exploration.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/Uplay/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Uplay/application.js:1
@@ -1315,211 +1315,211 @@
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry 3 - Blood Dragon/Uplay/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Beyond Good and Evil/Uplay/script.js:1
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Tom Clancy's Splinter Cell/Uplay/script.js:1
-!Uplay=
+Uplay=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Uplay Script/script.js:1
-!Uplay\ Script=
+Uplay\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Uplay/application.js:2
-!Uplay\ is\ Ubisoft's\ PC\ games\ portal.=
+Uplay\ is\ Ubisoft's\ PC\ games\ portal.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Apps/application.js:2
-!Utils\ for\ apps.=
+Utils\ for\ apps.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Filesystem/application.js:2
-!Utils\ for\ file\ system\ interaction.=
+Utils\ for\ file\ system\ interaction.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Utils/Functions/Net/application.js:2
-!Utils\ for\ interaction\ with\ the\ Internet.=
+Utils\ for\ interaction\ with\ the\ Internet.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Scribblenauts Unlimited/application.js:2
-!Venture\ into\ a\ wide-open\ world\ where\ the\ most\ powerful\ tool\ is\ your\ imagination.\ Help\ Maxwell\ solve\ robust\ puzzles\ in\ seamless,\ free-roaming\ levels\ by\ summoning\ any\ object\ you\ can\ think\ of.\ Create\ your\ own\ original\ objects,\ assign\ unique\ properties,\ and\ share\ them\ with\ friends\ online\ using\ Steam\ Workshop\ \u2013\ to\ be\ used\ in\ game\ or\ further\ modified\ as\ you\ like\!=
+Venture\ into\ a\ wide-open\ world\ where\ the\ most\ powerful\ tool\ is\ your\ imagination.\ Help\ Maxwell\ solve\ robust\ puzzles\ in\ seamless,\ free-roaming\ levels\ by\ summoning\ any\ object\ you\ can\ think\ of.\ Create\ your\ own\ original\ objects,\ assign\ unique\ properties,\ and\ share\ them\ with\ friends\ online\ using\ Steam\ Workshop\ \u2013\ to\ be\ used\ in\ game\ or\ further\ modified\ as\ you\ like\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/application.js:2
-!Verbs\ for\ Wine.=
+Verbs\ for\ Wine.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Mafia II/application.js:2
-!Vito\ Scaletta\ has\ started\ to\ make\ a\ name\ for\ himself\ on\ the\ streets\ of\ Empire\ Bay\ as\ someone\ who\ can\ be\ trusted\ to\ get\ a\ job\ done.\ Together\ with\ his\ buddy\ Joe,\ he\ is\ working\ to\ prove\ himself\ to\ the\ Mafia,\ quickly\ escalating\ up\ the\ family\ ladder\ with\ crimes\ of\ larger\ reward,\ status\ and\ consequence\u2026\ the\ life\ as\ a\ wise\ guy\ isn\u2019t\ quite\ as\ untouchable\ as\ it\ seems.=
+Vito\ Scaletta\ has\ started\ to\ make\ a\ name\ for\ himself\ on\ the\ streets\ of\ Empire\ Bay\ as\ someone\ who\ can\ be\ trusted\ to\ get\ a\ job\ done.\ Together\ with\ his\ buddy\ Joe,\ he\ is\ working\ to\ prove\ himself\ to\ the\ Mafia,\ quickly\ escalating\ up\ the\ family\ ladder\ with\ crimes\ of\ larger\ reward,\ status\ and\ consequence\u2026\ the\ life\ as\ a\ wise\ guy\ isn\u2019t\ quite\ as\ untouchable\ as\ it\ seems.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warcraft III Expansion Set/application.js:1
-!Warcraft\u00ae\ III\:\ Expansion\ Set=
+Warcraft\u00ae\ III\:\ Expansion\ Set=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warface/application.js:1
-!Warface=
+Warface=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warface/application.js:2
-!Warface\ offers\ an\ intense\ Co-op\ experience\ with\ daily\ new\ content,\ in\ which\ players\ can\ master\ unique\ teamwork\ moves\ and\ gameplay\ styles.\ They\ can\ also\ engage\ in\ fast-paced\ or\ tactical\ action\ in\ Versus\ modes\ such\ as\ Team\ Death\ Match\ or\ Plant\ The\ Bomb.=
+Warface\ offers\ an\ intense\ Co-op\ experience\ with\ daily\ new\ content,\ in\ which\ players\ can\ master\ unique\ teamwork\ moves\ and\ gameplay\ styles.\ They\ can\ also\ engage\ in\ fast-paced\ or\ tactical\ action\ in\ Versus\ modes\ such\ as\ Team\ Death\ Match\ or\ Plant\ The\ Bomb.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Warlock - Master of the Arcane/application.js:1
-!Warlock\ -\ Master\ of\ the\ Arcane=
+Warlock\ -\ Master\ of\ the\ Arcane=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/ChromaGun/application.js:2
-!Welcome\ to\ ChromaTec\u2019s\ test\ lab\!\ You\u2019re\ here\ to\ test\ our\ newest,\ state-of-the-art\ military-grade\ color-technology\:\ The\ ChromaGun\ (patent\ pending)\!\ Use\ it\ to\ try\ and\ solve\ our\ meticulously\ designed\ test\ chambers.\ The\ basic\ principle\ is\ as\ easy\ as\ applying\ it\ is\ complex\:\ Exit\ the\ chambers\ via\ the\ exit\ doors.\ But\ be\ weary\ of\ the\ WorkerDroids\ in\ charge\ of\ maintaining\ the\ chambers.\ They\u2019re\ not\ exactly\ what\ you\ and\ I\ would\ call\ \u201chuman\ friendly\u201d.<br><br>Use\ the\ ChromaGun\ to\ colorize\ walls\ and\ WorkerDroids\ to\ progress\ in\ the\ chambers.\ WorkerDroids\ are\ attracted\ to\ walls\ of\ the\ same\ color.\ Using\ that\ mechanic,\ try\ to\ reach\ the\ exit\ door\ of\ each\ chamber.\ Some\ doors\ are\ more\ complicated\ to\ use\ than\ others\:\ They\ can\ only\ be\ opened\ using\ door\ triggers\ and\ only\ stay\ open\ as\ long\ as\ the\ triggers\ are\ occupied.<br>br>If\ all\ of\ this\ sounds\ like\ your\ brain\ can\ handle\ it,\ congratulations\!\ You\u2019re\ the\ perfect\ candidate\ for\ our\ test\ chambers\!<br><br>That\ being\ said,\ welcome\ and\ good\ luck\!=
+Welcome\ to\ ChromaTec\u2019s\ test\ lab\!\ You\u2019re\ here\ to\ test\ our\ newest,\ state-of-the-art\ military-grade\ color-technology\:\ The\ ChromaGun\ (patent\ pending)\!\ Use\ it\ to\ try\ and\ solve\ our\ meticulously\ designed\ test\ chambers.\ The\ basic\ principle\ is\ as\ easy\ as\ applying\ it\ is\ complex\:\ Exit\ the\ chambers\ via\ the\ exit\ doors.\ But\ be\ weary\ of\ the\ WorkerDroids\ in\ charge\ of\ maintaining\ the\ chambers.\ They\u2019re\ not\ exactly\ what\ you\ and\ I\ would\ call\ \u201chuman\ friendly\u201d.<br><br>Use\ the\ ChromaGun\ to\ colorize\ walls\ and\ WorkerDroids\ to\ progress\ in\ the\ chambers.\ WorkerDroids\ are\ attracted\ to\ walls\ of\ the\ same\ color.\ Using\ that\ mechanic,\ try\ to\ reach\ the\ exit\ door\ of\ each\ chamber.\ Some\ doors\ are\ more\ complicated\ to\ use\ than\ others\:\ They\ can\ only\ be\ opened\ using\ door\ triggers\ and\ only\ stay\ open\ as\ long\ as\ the\ triggers\ are\ occupied.<br>br>If\ all\ of\ this\ sounds\ like\ your\ brain\ can\ handle\ it,\ congratulations\!\ You\u2019re\ the\ perfect\ candidate\ for\ our\ test\ chambers\!<br><br>That\ being\ said,\ welcome\ and\ good\ luck\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Unholy Heights/application.js:2
-!Welcome\ to\ Unholy\ Heights,\ a\ mashup\ of\ Tower\ Defense\ and\ Apartment\ Management\ Simulation\!\ The\ Devil\ has\ converted\ a\ tenement\ building\ into\ monsters-only\ housing,\ and\ has\ big\ plans\ for\ the\ future.\ Sucker\ monsters\ into\ moving\ into\ your\ building,\ charge\ them\ rent\ and\ keep\ them\ happy\ by\ buying\ them\ furniture.\ Unfortunately,\ heroes\ have\ caught\ wind\ of\ the\ Devil's\ plan,\ and\ will\ stop\ at\ nothing\ to\ wipe\ him\ out.\ Knock\ on\ residents'\ doors\ to\ call\ them\ to\ battle,\ trap\ heroes\ in\ devious\ pincer\ formations,\ and\ command\ your\ troops\ to\ victory.\ Monsters\ get\ jobs,\ fall\ in\ love,\ have\ children,\ and\ even\ skip\ out\ on\ their\ rent.\ Keep\ them\ happy\ or\ you\ might\ not\ have\ anyone\ to\ fight\ for\ you\ when\ heroes\ come\ knocking.\ But\ don't\ be\ too\ soft\:\ there's\ always\ prospective\ baddies\ looking\ to\ move\ in,\ so\ kick\ out\ the\ freeloaders\ when\ the\ time\ is\ right\!\ Being\ a\ landlord\ is\ a\ difficult\ job,\ but\ it\ can't\ be\ harder\ than\ running\ Hell...right?=
+Welcome\ to\ Unholy\ Heights,\ a\ mashup\ of\ Tower\ Defense\ and\ Apartment\ Management\ Simulation\!\ The\ Devil\ has\ converted\ a\ tenement\ building\ into\ monsters-only\ housing,\ and\ has\ big\ plans\ for\ the\ future.\ Sucker\ monsters\ into\ moving\ into\ your\ building,\ charge\ them\ rent\ and\ keep\ them\ happy\ by\ buying\ them\ furniture.\ Unfortunately,\ heroes\ have\ caught\ wind\ of\ the\ Devil's\ plan,\ and\ will\ stop\ at\ nothing\ to\ wipe\ him\ out.\ Knock\ on\ residents'\ doors\ to\ call\ them\ to\ battle,\ trap\ heroes\ in\ devious\ pincer\ formations,\ and\ command\ your\ troops\ to\ victory.\ Monsters\ get\ jobs,\ fall\ in\ love,\ have\ children,\ and\ even\ skip\ out\ on\ their\ rent.\ Keep\ them\ happy\ or\ you\ might\ not\ have\ anyone\ to\ fight\ for\ you\ when\ heroes\ come\ knocking.\ But\ don't\ be\ too\ soft\:\ there's\ always\ prospective\ baddies\ looking\ to\ move\ in,\ so\ kick\ out\ the\ freeloaders\ when\ the\ time\ is\ right\!\ Being\ a\ landlord\ is\ a\ difficult\ job,\ but\ it\ can't\ be\ harder\ than\ running\ Hell...right?=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Origin/Local (Legacy)/script.js:16
 #: /home/klara/.Phoenicis/Scripts/Applications/Games/Origin/Online (Legacy)/script.js:15
-!When\ Origin\ launches,\ you\ will\ get\ an\ error\ message\ ("Your\ update\ could\ not\ be\ completed.").\ This\ is\ ok.\ Just\ close\ the\ popup.=
+When\ Origin\ launches,\ you\ will\ get\ an\ error\ message\ ("Your\ update\ could\ not\ be\ completed.").\ This\ is\ ok.\ Just\ close\ the\ popup.=
 
 #: /home/klara/.Phoenicis/Scripts/Applications/Internet/Internet Explorer 7.0/Online/script.js:64
-!Which\ language\ version\ would\ you\ like\ to\ install?=
+Which\ language\ version\ would\ you\ like\ to\ install?=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Wildlife Park 2/application.js:1
-!Wildlife\ Park\ 2=
+Wildlife\ Park\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/Windows XP SP 3/script.js:1
-!Windows\ XP\ Service\ Pack\ 3=
+Windows\ XP\ Service\ Pack\ 3=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Reboot Wine/script.js:1
-!Windows\ reboot=
+Windows\ reboot=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/category.js:1
-!Wine=
+Wine=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Engine/application.js:1
-!Wine\ Engine=
+Wine\ Engine=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Shortcuts/Wine/script.js:1
-!Wine\ Shortcut=
+Wine\ Shortcut=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Shortcuts/application.js:1
-!Wine\ Shortcuts=
+Wine\ Shortcuts=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/application.js:1
-!Wine\ Tools=
+Wine\ Tools=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/application.js:1
-!Wine\ Verbs=
+Wine\ Verbs=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Engine/Object/script.js:1
-!Wine\ engine=
+Wine\ engine=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Tools/Wine Uninstaller/script.js:1
-!Wine\ uninstaller=
+Wine\ uninstaller=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Elder Scrolls V: Skyrim/application.js:2
-!Winner\ of\ more\ than\ 200\ Game\ of\ the\ Year\ Awards,\ Skyrim\ Special\ Edition\ brings\ the\ epic\ fantasy\ to\ life\ in\ stunning\ detail.\ The\ Special\ Edition\ includes\ the\ critically\ acclaimed\ game\ and\ add-ons\ with\ all-new\ features\ like\ remastered\ art\ and\ effects,\ volumetric\ god\ rays,\ dynamic\ depth\ of\ field,\ screen-space\ reflections,\ and\ more.\ Skyrim\ Special\ Edition\ also\ brings\ the\ full\ power\ of\ mods\ to\ the\ PC\ and\ consoles.\ New\ quests,\ environments,\ characters,\ dialogue,\ armor,\ weapons\ and\ more\ \u2013\ with\ Mods,\ there\ are\ no\ limits\ to\ what\ you\ can\ experience.=
+Winner\ of\ more\ than\ 200\ Game\ of\ the\ Year\ Awards,\ Skyrim\ Special\ Edition\ brings\ the\ epic\ fantasy\ to\ life\ in\ stunning\ detail.\ The\ Special\ Edition\ includes\ the\ critically\ acclaimed\ game\ and\ add-ons\ with\ all-new\ features\ like\ remastered\ art\ and\ effects,\ volumetric\ god\ rays,\ dynamic\ depth\ of\ field,\ screen-space\ reflections,\ and\ more.\ Skyrim\ Special\ Edition\ also\ brings\ the\ full\ power\ of\ mods\ to\ the\ PC\ and\ consoles.\ New\ quests,\ environments,\ characters,\ dialogue,\ armor,\ weapons\ and\ more\ \u2013\ with\ Mods,\ there\ are\ no\ limits\ to\ what\ you\ can\ experience.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Worms Armageddon/application.js:1
-!Worms\ Armageddon=
+Worms\ Armageddon=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Worms Reloaded/application.js:1
-!Worms\u2122\ Reloaded=
+Worms\u2122\ Reloaded=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Worms Reloaded/application.js:2
-!Worms\u2122\ Reloaded\ is\ a\ turn-based\ computer\ games\ developed\ by\ Team17\ Software.\ Players\ control\ a\ small\ platoon\ of\ earthworms\ across\ a\ deformable\ landscape,\ battling\ other\ computer-\ or\ player-controlled\ teams.\ The\ games\ feature\ bright\ and\ humorous\ cartoon-style\ animation\ and\ a\ varied\ arsenal\ of\ bizarre\ weapons.=
+Worms\u2122\ Reloaded\ is\ a\ turn-based\ computer\ games\ developed\ by\ Team17\ Software.\ Players\ control\ a\ small\ platoon\ of\ earthworms\ across\ a\ deformable\ landscape,\ battling\ other\ computer-\ or\ player-controlled\ teams.\ The\ games\ feature\ bright\ and\ humorous\ cartoon-style\ animation\ and\ a\ varied\ arsenal\ of\ bizarre\ weapons.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Xenon 2/application.js:1
-!Xenon\ 2=
+Xenon\ 2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Far Cry 2/application.js:2
-!You\ are\ a\ gun\ for\ hire,\ trapped\ in\ a\ war-torn\ African\ state,\ stricken\ with\ malaria\ and\ forced\ to\ make\ deals\ with\ corrupt\ warlords\ on\ both\ sides\ of\ the\ conflict\ in\ order\ to\ make\ this\ country\ your\ home.<br><br>You\ must\ identify\ and\ exploit\ your\ enemies'\ weaknesses,\ neutralizing\ their\ superior\ numbers\ and\ firepower\ with\ surprise,\ subversion,\ cunning\ and\ of\ course\ brute\ force.=
+You\ are\ a\ gun\ for\ hire,\ trapped\ in\ a\ war-torn\ African\ state,\ stricken\ with\ malaria\ and\ forced\ to\ make\ deals\ with\ corrupt\ warlords\ on\ both\ sides\ of\ the\ conflict\ in\ order\ to\ make\ this\ country\ your\ home.<br><br>You\ must\ identify\ and\ exploit\ your\ enemies'\ weaknesses,\ neutralizing\ their\ superior\ numbers\ and\ firepower\ with\ surprise,\ subversion,\ cunning\ and\ of\ course\ brute\ force.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Command and Conquer - Tiberium Wars/application.js:2
-!You\ are\ in\ command\ of\ the\ armies\ of\ either\ GDI\ or\ NOD\ with\ the\ fate\ of\ Earth\ in\ the\ balance.=
+You\ are\ in\ command\ of\ the\ armies\ of\ either\ GDI\ or\ NOD\ with\ the\ fate\ of\ Earth\ in\ the\ balance.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/BRINK/application.js:2
-!You\ decide\ the\ combat\ role\ you\ want\ to\ assume\ in\ the\ world\ of\ Brink\ as\ you\ fight\ to\ save\ yourself\ and\ mankind\u2019s\ last\ refuge\!=
+You\ decide\ the\ combat\ role\ you\ want\ to\ assume\ in\ the\ world\ of\ Brink\ as\ you\ fight\ to\ save\ yourself\ and\ mankind\u2019s\ last\ refuge\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Druid Soccer/application.js:2
-!You\ take\ part\ in\ the\ ancient\ traditional\ game\ of\ Druid\ Soccer.=
+You\ take\ part\ in\ the\ ancient\ traditional\ game\ of\ Druid\ Soccer.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Witness/application.js:2
-!You\ wake\ up,\ alone,\ on\ a\ strange\ island\ full\ of\ puzzles\ that\ will\ challenge\ and\ surprise\ you.<br><br>You\ don't\ remember\ who\ you\ are,\ and\ you\ don't\ remember\ how\ you\ got\ here,\ but\ there's\ one\ thing\ you\ can\ do\:\ explore\ the\ island\ in\ hope\ of\ discovering\ clues,\ regaining\ your\ memory,\ and\ somehow\ finding\ your\ way\ home.<br><br>The\ Witness\ is\ a\ single-player\ game\ in\ an\ open\ world\ with\ dozens\ of\ locations\ to\ explore\ and\ over\ 500\ puzzles.\ This\ game\ respects\ you\ as\ an\ intelligent\ player\ and\ it\ treats\ your\ time\ as\ precious.\ There's\ no\ filler;\ each\ of\ those\ puzzles\ brings\ its\ own\ new\ idea\ into\ the\ mix.\ So,\ this\ is\ a\ game\ full\ of\ ideas.=
+You\ wake\ up,\ alone,\ on\ a\ strange\ island\ full\ of\ puzzles\ that\ will\ challenge\ and\ surprise\ you.<br><br>You\ don't\ remember\ who\ you\ are,\ and\ you\ don't\ remember\ how\ you\ got\ here,\ but\ there's\ one\ thing\ you\ can\ do\:\ explore\ the\ island\ in\ hope\ of\ discovering\ clues,\ regaining\ your\ memory,\ and\ somehow\ finding\ your\ way\ home.<br><br>The\ Witness\ is\ a\ single-player\ game\ in\ an\ open\ world\ with\ dozens\ of\ locations\ to\ explore\ and\ over\ 500\ puzzles.\ This\ game\ respects\ you\ as\ an\ intelligent\ player\ and\ it\ treats\ your\ time\ as\ precious.\ There's\ no\ filler;\ each\ of\ those\ puzzles\ brings\ its\ own\ new\ idea\ into\ the\ mix.\ So,\ this\ is\ a\ game\ full\ of\ ideas.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/The Crew/application.js:2
-!Your\ car\ is\ your\ avatar\ -\ fine\ tune\ your\ ride\ as\ you\ level\ up\ and\ progress\ through\ 5\ unique\ and\ richly\ detailed\ regions\ of\ a\ massive\ open-world\ US.\ Maneuver\ through\ the\ bustling\ streets\ of\ New\ York\ City\ and\ Los\ Angeles,\ cruise\ down\ sunny\ Miami\ Beach\ or\ trek\ through\ the\ breathtaking\ plateaus\ of\ Monument\ Valley.\ Each\ locale\ comes\ with\ its\ own\ set\ of\ surprises\ and\ driving\ challenges\ to\ master.\ On\ your\ journey\ you\ will\ encounter\ other\ players\ on\ the\ road\ \u2013\ all\ potentially\ worthy\ companions\ to\ crew\ up\ with,\ or\ future\ rivals\ to\ compete\ against.\ This\ is\ driving\ at\ its\ most\ exciting,\ varied\ and\ open.=
+Your\ car\ is\ your\ avatar\ -\ fine\ tune\ your\ ride\ as\ you\ level\ up\ and\ progress\ through\ 5\ unique\ and\ richly\ detailed\ regions\ of\ a\ massive\ open-world\ US.\ Maneuver\ through\ the\ bustling\ streets\ of\ New\ York\ City\ and\ Los\ Angeles,\ cruise\ down\ sunny\ Miami\ Beach\ or\ trek\ through\ the\ breathtaking\ plateaus\ of\ Monument\ Valley.\ Each\ locale\ comes\ with\ its\ own\ set\ of\ surprises\ and\ driving\ challenges\ to\ master.\ On\ your\ journey\ you\ will\ encounter\ other\ players\ on\ the\ road\ \u2013\ all\ potentially\ worthy\ companions\ to\ crew\ up\ with,\ or\ future\ rivals\ to\ compete\ against.\ This\ is\ driving\ at\ its\ most\ exciting,\ varied\ and\ open.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/QuickScript/Zip Script/script.js:1
-!Zip\ Script=
+Zip\ Script=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/corefonts/script.js:1
-!corefonts=
+corefonts=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/crypt32/script.js:1
-!crypt32=
+crypt32=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/d3dx10/script.js:1
-!d3dx10=
+d3dx10=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/d3dx9/script.js:1
-!d3dx9=
+d3dx9=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/corefonts/script.js:84
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/corefonts/script.js:90
-!fonts=
+fonts=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/luna/script.js:1
-!luna=
+luna=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/mIRC/application.js:1
-!mIRC=
+mIRC=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/mfc42/script.js:1
-!mfc42=
+mfc42=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/msls31/script.js:1
-!msls31=
+msls31=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/mspatcha/script.js:1
-!mspatcha=
+mspatcha=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/osu!/application.js:1
-!osu\!=
+osu\!=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/osu!/application.js:2
-!osu\!\ is\ a\ free-to-win\ online\ rhythm\ game.=
+osu\!\ is\ a\ free-to-win\ online\ rhythm\ game.=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/quartz/script.js:1
-!quartz=
+quartz=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/sandbox/script.js:1
-!sandbox=
+sandbox=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/secur32/script.js:1
-!secur32=
+secur32=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Development/Notepad++/v7.2.2/script.js:1
-!v.7.2.2=
+v.7.2.2=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/Icy Tower/v1.5/script.js:1
-!v1.5=
+v1.5=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/TeamSpeak 3/v3.0.19.4/script.js:1
-!v3.0.19.4=
+v3.0.19.4=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Internet/mIRC/v7.46/script.js:1
-!v7.46=
+v7.46=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2003/script.js:1
-!vcrun2003=
+vcrun2003=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2005/script.js:1
-!vcrun2005=
+vcrun2005=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2008/script.js:1
-!vcrun2008=
+vcrun2008=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2010/script.js:1
-!vcrun2010=
+vcrun2010=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2012/script.js:1
-!vcrun2012=
+vcrun2012=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2013/script.js:1
-!vcrun2013=
+vcrun2013=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/vcrun2015/script.js:1
-!vcrun2015=
+vcrun2015=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Engines/Wine/Verbs/xact/script.js:1
-!xact=
+xact=
 
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/dotnet452/script.js:49
 #: /home/klara/.Phoenicis/Scripts/Engines/Wine/Verbs/dotnet45/script.js:50
-!{0}\ applications\ can\ have\ issues\ when\ windows\ version\ is\ not\ set\ to\ "win2003"=
+{0}\ applications\ can\ have\ issues\ when\ windows\ version\ is\ not\ set\ to\ "win2003"=
 
 #: /home/klara/.Phoenicis/Scripts/i18n/tmp/Applications/Games/It came from space and ate our brains/application.js:2
-!\u2018It\ came\ from\ space,\ and\ ate\ our\ brains\u2019\ is\ an\ Arcade\ top\ down\ shooter\ with\ horde\ survival\ gameplay\ in\ a\ unique\ atmospheric\ setting\ with\ addicting\ gameplay\ elements,\ which\ all\ can\ be\ played\ cooperatively.\ You\ are\ a\ no-nonsense\ kind\ of\ guy\ equipped\ with\ a\ flashlight\ and\ a\ weapon.\ You\ somehow\ managed\ to\ survive\ the\ invasion\ of\ a\ merciless\ alien\ species,\ the\ kind\ that\ feeds\ on\ human\ brains.\ Things\ look\ bad\ when\ you\ wander\ the\ city\ and\ other\ locations,\ there\ is\ chaos\ everywhere\!\ You\ are\ looking\ for\ gear\ and\ weapons\ to\ survive,\ as\ pink\ light\ emitting\ aliens\ try\ to\ corner\ you\ and\ eat\ your\ brain.\ You\ realize\ there\ is\ only\ one\ thing\ left\ to\ do\:\ set\ a\ new\ high\ score\ and\ die\ like\ a\ badass.=
+\u2018It\ came\ from\ space,\ and\ ate\ our\ brains\u2019\ is\ an\ Arcade\ top\ down\ shooter\ with\ horde\ survival\ gameplay\ in\ a\ unique\ atmospheric\ setting\ with\ addicting\ gameplay\ elements,\ which\ all\ can\ be\ played\ cooperatively.\ You\ are\ a\ no-nonsense\ kind\ of\ guy\ equipped\ with\ a\ flashlight\ and\ a\ weapon.\ You\ somehow\ managed\ to\ survive\ the\ invasion\ of\ a\ merciless\ alien\ species,\ the\ kind\ that\ feeds\ on\ human\ brains.\ Things\ look\ bad\ when\ you\ wander\ the\ city\ and\ other\ locations,\ there\ is\ chaos\ everywhere\!\ You\ are\ looking\ for\ gear\ and\ weapons\ to\ survive,\ as\ pink\ light\ emitting\ aliens\ try\ to\ corner\ you\ and\ eat\ your\ brain.\ You\ realize\ there\ is\ only\ one\ thing\ left\ to\ do\:\ set\ a\ new\ high\ score\ and\ die\ like\ a\ badass.=

--- a/i18n/update_translations.py
+++ b/i18n/update_translations.py
@@ -88,3 +88,18 @@ with open(properties_file) as input_file:
 with open(properties_file, 'w') as output_file:
     for line in lines:
         output_file.write(line)
+
+# delete comments (why are they here?)
+lines = []
+regex = re.compile(r"^\!")
+regex_header = re.compile(r"^\!=Project-Id-Version")
+with open(properties_file) as input_file:
+    for line in input_file:
+        # keep the header comment
+        if regex_header.match(line):
+            lines.append(line)
+        else:
+            lines.append(regex.sub("", line))
+with open(properties_file, 'w') as output_file:
+    for line in lines:
+        output_file.write(line)


### PR DESCRIPTION
For whatever reason, xgettext comments all strings in the .properties. I couldn't figure out why this happens so this PR just uses a regex to remove them again after the .properties has been created.

This will probably solve the issue that Crowdin doesn't find any strings in the translation files.