### PR TITLE
Update SteamScript with new sha1sum

### DIFF
--- a/Engines/Wine/QuickScript/Steam Script/script.js
+++ b/Engines/Wine/QuickScript/Steam Script/script.js
@@ -90,7 +90,7 @@ SteamScript.prototype.go = function () {
     new Downloader()
         .wizard(setupWizard)
         .url("http://media.steampowered.com/client/installer/SteamSetup.exe")
-        .checksum("e930dbdb3bc638f772a8fcd92dbcd0919c924318")
+        .checksum("4b1b85ec2499a4ce07c89609b256923a4fc479e5")
         .to(tempFile)
         .get();
 


### PR DESCRIPTION
Valve changed their SteamInstaller.exe file so the checksum is no longer correct and every steam game instalation crashes.