### PR TITLE
Wine#run(): do not wait for wineserver

### DIFF
--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -20,15 +20,6 @@ var engineImplementation = {
     _wineWebServiceUrl : Bean("propertyReader").getProperty("webservice.wine.url"),
     _wizard: null,
     _workingContainer: "",
-    _wineServer: function (subCategory, version, parameter) {
-        var binary = this.getLocalDirectory(subCategory, version) + "/bin/wineserver";
-        var processBuilder = new java.lang.ProcessBuilder(Java.to([binary, parameter], "java.lang.String[]"));
-        var environment = processBuilder.environment();
-        environment.put("WINEPREFIX", this.getContainerDirectory(this.getWorkingContainer()));
-        processBuilder.inheritIO();
-        var wineServerProcess = processBuilder.start();
-        wineServerProcess.waitFor();
-    },
     getLocalDirectory: function (subCategory, version) {
         var parts = subCategory.split("-");
         var distribution = parts[0];
@@ -271,7 +262,6 @@ var engineImplementation = {
 
         if (wait) {
             process.waitFor();
-            this._wineServer(subCategory, version, "-w");
         }
 
         if (captureOutput) {

--- a/Engines/Wine/QuickScript/Steam Script/script.js
+++ b/Engines/Wine/QuickScript/Steam Script/script.js
@@ -70,9 +70,17 @@ SteamScript.prototype.downloadFinished = function (wine) {
     }
 };
 
-// Fix for the "content server unavaiable" error (Wine bug 45329)
+SteamScript.prototype.configVdf = function (wine) {
+    if (!this._configVdf) {
+        // cache config.vdf path (will not change during the installation)
+        this._configVdf = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/config/config.vdf";
+    }
+    return this._configVdf;
+};
+
+// Fix for the "content server unavailable" error (Wine bug 45329)
 SteamScript.prototype.fixCertificateIssue = function (wine){
-    var steamConfigFile = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/config/config.vdf";
+    var steamConfigFile = this.configVdf(wine);
     var steamConfig = cat(steamConfigFile);
     var cmPos = steamConfig.indexOf("\"CM\"");
     var csConfig = "\"CS\" \"valve511.steamcontent.com;valve501.steamcontent.com;valve517.steamcontent.com;valve557.steamcontent.com;valve513.steamcontent.com;valve535.steamcontent.com;valve546.steamcontent.com;valve538.steamcontent.com;valve536.steamcontent.com;valve530.steamcontent.com;valve559.steamcontent.com;valve545.steamcontent.com;valve518.steamcontent.com;valve548.steamcontent.com;valve555.steamcontent.com;valve556.steamcontent.com;valve506.steamcontent.com;valve544.steamcontent.com;valve525.steamcontent.com;valve567.steamcontent.com;valve521.steamcontent.com;valve510.steamcontent.com;valve542.steamcontent.com;valve519.steamcontent.com;valve526.steamcontent.com;valve504.steamcontent.com;valve500.steamcontent.com;valve554.steamcontent.com;valve562.steamcontent.com;valve524.steamcontent.com;valve502.steamcontent.com;valve505.steamcontent.com;valve547.steamcontent.com;valve560.steamcontent.com;valve503.steamcontent.com;valve507.steamcontent.com;valve553.steamcontent.com;valve520.steamcontent.com;valve550.steamcontent.com;valve531.steamcontent.com;valve558.steamcontent.com;valve552.steamcontent.com;valve563.steamcontent.com;valve540.steamcontent.com;valve541.steamcontent.com;valve537.steamcontent.com;valve528.steamcontent.com;valve523.steamcontent.com;valve512.steamcontent.com;valve532.steamcontent.com;valve561.steamcontent.com;valve549.steamcontent.com;valve522.steamcontent.com;valve514.steamcontent.com;valve551.steamcontent.com;valve564.steamcontent.com;valve543.steamcontent.com;valve565.steamcontent.com;valve529.steamcontent.com;valve539.steamcontent.com;valve566.steamcontent.com;valve165.steamcontent.com;valve959.steamcontent.com;valve164.steamcontent.com;valve1611.steamcontent.com;valve1601.steamcontent.com;valve1617.steamcontent.com;valve1603.steamcontent.com;valve1602.steamcontent.com;valve1610.steamcontent.com;valve1615.steamcontent.com;valve909.steamcontent.com;valve900.steamcontent.com;valve905.steamcontent.com;valve954.steamcontent.com;valve955.steamcontent.com;valve1612.steamcontent.com;valve1607.steamcontent.com;valve1608.steamcontent.com;valve1618.steamcontent.com;valve1619.steamcontent.com;valve1606.steamcontent.com;valve1605.steamcontent.com;valve1609.steamcontent.com;valve907.steamcontent.com;valve901.steamcontent.com;valve902.steamcontent.com;valve1604.steamcontent.com;valve908.steamcontent.com;valve950.steamcontent.com;valve957.steamcontent.com;valve903.steamcontent.com;valve1614.steamcontent.com;valve904.steamcontent.com;valve952.steamcontent.com;valve1616.steamcontent.com;valve1613.steamcontent.com;valve958.steamcontent.com;valve956.steamcontent.com;valve906.steamcontent.com\"\n";
@@ -112,6 +120,17 @@ SteamScript.prototype.go = function () {
     // Steam must be started once such that config.vdf is created (see fixCertificateIssue())
     setupWizard.wait(tr("Please follow the steps of the Steam setup. Then, wait until Steam is updated, log in and finally close Steam completely so the installation of \"{0}\" can continue.", this._name));
     wine.run(tempFile, [], null, false, true);
+
+    // ensure that Steam is running (user might have unchecked "run Steam after installation finished")
+    wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", ["steam://nav/games"], false);
+
+    // wait until config.vdf exists
+    while (!fileExists(this.configVdf(wine))) {
+        java.lang.Thread.sleep(1000);
+    }
+
+    // wait until Steam and Wine are closed
+    wine.wait();
 
     this.fixCertificateIssue(wine);
 


### PR DESCRIPTION
If multiple programs are running in a prefix, `wineserver -w` will wait until all of them are finished. Therefore, the `wait` parameter in `Wine#run()` waits only until the started process is finished. `Wine#wait` can be used to explicitly wait until the wineserver is closed.

fixes #671 