### PR TITLE
Fix mspatcha URL

### DIFF
--- a/Engines/Wine/Verbs/mspatcha/script.js
+++ b/Engines/Wine/Verbs/mspatcha/script.js
@@ -11,7 +11,7 @@ Wine.prototype.mspatcha = function () {
     //Inspired from winetricks mspatcha, but with a link Phoenicis can understand
     var setupFile = new Resource()
         .wizard(this.wizard())
-        .url("https://web.archive.org/web/20060319175746/http://download.microsoft.com/download/e/6/a/e6a04295-d2a8-40d0-a0c5-241bfecd095e/w2ksp4_en.exe")
+        .url("https://web.archive.org/web/20060319175746if_/http://download.microsoft.com/download/e/6/a/e6a04295-d2a8-40d0-a0c5-241bfecd095e/w2ksp4_en.exe")
         .checksum("fadea6d94a014b039839fecc6e6a11c20afa4fa8")
         .name("W2ksp4_EN.exe")
         .get();

--- a/Engines/Wine/Verbs/mspatcha/script.js
+++ b/Engines/Wine/Verbs/mspatcha/script.js
@@ -11,7 +11,7 @@ Wine.prototype.mspatcha = function () {
     //Inspired from winetricks mspatcha, but with a link Phoenicis can understand
     var setupFile = new Resource()
         .wizard(this.wizard())
-        .url("http://ftp.anadolu.edu.tr/Service_Packs/Windows_2000/W2ksp4_EN.exe")
+        .url("https://web.archive.org/web/20060319175746/http://download.microsoft.com/download/e/6/a/e6a04295-d2a8-40d0-a0c5-241bfecd095e/w2ksp4_en.exe")
         .checksum("fadea6d94a014b039839fecc6e6a11c20afa4fa8")
         .name("W2ksp4_EN.exe")
         .get();

--- a/Engines/Wine/Verbs/mspatcha/script.js
+++ b/Engines/Wine/Verbs/mspatcha/script.js
@@ -11,7 +11,7 @@ Wine.prototype.mspatcha = function () {
     //Inspired from winetricks mspatcha, but with a link Phoenicis can understand
     var setupFile = new Resource()
         .wizard(this.wizard())
-        .url("https://web.archive.org/web/20060319175746if_/http://download.microsoft.com/download/e/6/a/e6a04295-d2a8-40d0-a0c5-241bfecd095e/w2ksp4_en.exe")
+        .url("https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/win2000/Service_Packs/usa/W2KSP4_EN.EXE")
         .checksum("fadea6d94a014b039839fecc6e6a11c20afa4fa8")
         .name("W2ksp4_EN.exe")
         .get();


### PR DESCRIPTION
This pull request resolves issue #706. The URL for mspatcha is changed from 
```
http://ftp.anadolu.edu.tr/Service_Packs/Windows_2000/W2ksp4_EN.exe"
```
to
```
https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/win2000/Service_Packs/usa/W2KSP4_EN.EXE
```

Note that this file has the same SHA1 checksum as the original link at (http://ftp.anadolu.edu.tr/Service_Packs/Windows_2000/W2ksp4_EN.exe):
```
fadea6d94a014b039839fecc6e6a11c20afa4fa8
```