### PR TITLE
Games/Hearthstone : Update, fixes

### DIFF
--- a/Applications/Games/Hearthstone/Online/script.js
+++ b/Applications/Games/Hearthstone/Online/script.js
@@ -1,11 +1,6 @@
 include(["engines", "wine", "quick_script", "online_installer_script"]);
-include(["engines", "wine", "plugins", "windows_version"]);
 include(["engines", "wine", "verbs", "vcrun2015"]);
 include(["engines", "wine", "verbs", "corefonts"]);
-
-// CHANGELOG
-// 2019/01/09 // Kreyren - Changed executable on Battle.net.exe, mandatory for battle.net games
-// 2019/01/09 // Kreyren - Changed WINE from winxp on win7 since winxp will soon be unsupported
 
 // BUG: https://github.com/PhoenicisOrg/scripts/issues/792
 
@@ -24,7 +19,6 @@ var installerImplementation = {
             .wineVersion(LATEST_STAGING_VERSION)
             .wineDistribution("staging")
             .preInstall(function (wine/*, wizard*/) {
-                wine.windowsVersion("win7");
                 wine.vcrun2015();
                 wine.corefonts();
             })

--- a/Applications/Games/Hearthstone/Online/script.js
+++ b/Applications/Games/Hearthstone/Online/script.js
@@ -3,20 +3,28 @@ include(["engines", "wine", "plugins", "windows_version"]);
 include(["engines", "wine", "verbs", "vcrun2015"]);
 include(["engines", "wine", "verbs", "corefonts"]);
 
+// CHANGELOG
+// 2019/01/09 // Kreyren - Changed executable on Battle.net.exe, mandatory for battle.net games
+// 2019/01/09 // Kreyren - Changed WINE from winxp on win7 since winxp will soon be unsupported
+
+// BUG: https://github.com/PhoenicisOrg/scripts/issues/792
+
+// TODO: OSX support, needs verification
+
 var installerImplementation = {
     run: function () {
         new OnlineInstallerScript()
             .name("Hearthstone")
             .editor("Blizzard")
             .applicationHomepage("https://eu.battle.net/hearthstone/")
-            .author("ImperatorS79")
+            .author("ImperatorS79, kreyren")
             .url("https://eu.battle.net/download/getInstaller?os=win&installer=Hearthstone-Setup.exe")
             .category("Games")
-            .executable("Hearthstone.exe")
+            .executable("Battle.net.exe")
             .wineVersion(LATEST_STAGING_VERSION)
             .wineDistribution("staging")
             .preInstall(function (wine/*, wizard*/) {
-                wine.windowsVersion("winxp");
+                wine.windowsVersion("win7");
                 wine.vcrun2015();
                 wine.corefonts();
             })


### PR DESCRIPTION
Bug : #792
Changes WINE environment from winxp to win7 -> winxp outputs error about unsupported OS.
Changes executable to workaround #792
Tested, working
Signed-off-by: Jacob Hrbek <werifgx@gmail.com>