### PR TITLE
Update Starcraft II (use latest stable Wine, fix executable name)

### DIFF
--- a/Applications/Games/Star Craft II/Online/script.js
+++ b/Applications/Games/Star Craft II/Online/script.js
@@ -13,8 +13,6 @@ var installerImplementation = {
         // The checksum changes each time you download
             .category("Games")
             .executable("Battle.net.exe")
-            .wineVersion(LATEST_STABLE_VERSION)
-            .wineDistribution("upstream")
             .preInstall(function (wine/*, wizard*/) {
                 wine.vcrun2015();
                 wine.corefonts();

--- a/Applications/Games/Star Craft II/Online/script.js
+++ b/Applications/Games/Star Craft II/Online/script.js
@@ -12,9 +12,9 @@ var installerImplementation = {
             .url("https://eu.battle.net/download/getInstaller?os=win&installer=StarCraft-II-Setup.exe")
         // The checksum changes each time you download
             .category("Games")
-            .executable("StarCraft II.exe")
-            .wineVersion("3.19")
-            .wineDistribution("staging")
+            .executable("Battle.net.exe")
+            .wineVersion(LATEST_STABLE_VERSION)
+            .wineDistribution("upstream")
             .preInstall(function (wine/*, wizard*/) {
                 wine.vcrun2015();
                 wine.corefonts();


### PR DESCRIPTION
So here's the story:
An user form POL4 website was reporting the POL4 version of this script wasn't working due to broken link in flashplayer. I've told him to switch to POL5 since it have a more active support. Right after that I've checked if the script is still working. Right after the login screen appeared I get the "Starcraft2.exe not found" error. The script dosen't wait long enough so I did what @Kreyren did and changed it to Battle.net.exe
And while I was at it I've changed `wineVersion` to use the latest stable Wine. 