### PR TITLE
Games/RocketLeague : Initial Commit

### DIFF
--- a/Applications/Games/RocketLeague/CONCEPT.md
+++ b/Applications/Games/RocketLeague/CONCEPT.md
@@ -1,0 +1,13 @@
+### Abstract
+
+Make Rocket League work on WINE.
+
+Export shaders to prevent freezes if Psyonic won't fix em.
+
+Make game rescale on whole fullscreen if different resolution is used.
+
+If DirectX 9 is used make it work on DXVK.
+
+### Research
+
+%%

--- a/Applications/Games/RocketLeague/Online/script.js
+++ b/Applications/Games/RocketLeague/Online/script.js
@@ -1,0 +1,1 @@
+// WORK IN PROGRESS

--- a/Applications/Games/RocketLeague/Online/script.json
+++ b/Applications/Games/RocketLeague/Online/script.json
@@ -1,0 +1,14 @@
+{
+    "scriptName"                 : "Online",
+    "id"                         : "online",
+    "compatibleOperatingSystems" : [
+        "MACOSX",
+        "LINUX"
+    ],
+    "testingOperatingSystems" : [
+        "MACOSX",
+        "LINUX"
+    ],
+    "free"                    : true,
+    "requiresPatch"           : false
+}

--- a/Applications/Games/RocketLeague/Steam/script.js
+++ b/Applications/Games/RocketLeague/Steam/script.js
@@ -1,0 +1,20 @@
+include("engines.wine.quick_script.steam_script");
+
+var installerImplementation = {
+    run: function () {
+        new SteamScript()
+            .name("Rocket League")
+            .editor("Psyonix, Panic Button Games")
+            .publisher("Psyonix")
+            .author("Kreyren")
+            .appId(252950)
+            .wineVersion("3.16-7 Beta") // Needs sanity check
+            .wineDistribution("proton") // Needs sanity check
+            .gameOverlay(false) // May be required for in-game purchases
+            .category("Games/esport") // Sanity check
+            .go();
+    }
+};
+
+/* exported Installer */
+var Installer = Java.extend(org.phoenicis.scripts.Installer, installerImplementation);

--- a/Applications/Games/RocketLeague/Steam/script.json
+++ b/Applications/Games/RocketLeague/Steam/script.json
@@ -1,0 +1,14 @@
+{
+    "scriptName"                 : "Steam",
+    "id"                         : "steam",
+    "compatibleOperatingSystems" : [
+        "MACOSX",
+        "LINUX"
+    ],
+    "testingOperatingSystems" : [
+        "MACOSX",
+        "LINUX"
+    ],
+    "free"                    : true,
+    "requiresPatch"           : false
+}

--- a/Applications/Games/RocketLeague/application.json
+++ b/Applications/Games/RocketLeague/application.json
@@ -1,0 +1,5 @@
+{
+    "name"        : "Rocket League",
+    "id"          : "rocket_league",
+    "description" : "Rocket League is a vehicular soccer video game developed and published by Psyonix. The game was first released for Microsoft Windows and PlayStation 4 in July 2015, with ports for Xbox One, macOS, Linux, and Nintendo Switch being released later on."
+}


### PR DESCRIPTION
### Abstract

Make Rocket League work on WINE.

Export shaders to prevent freezes if Psyonic won't fix em.

Make game rescale on whole fullscreen if different resolution is used.

If DirectX 9 is used make it work on DXVK.

Click play -> Opens a game.

### Reasoning

Game has native support which seems to be WINE wrapped.
- Has freezes if player enters/interact with new object -> Shader issue?
- Is unable to scale on fullscreen if smaller resolution is used.
- Could benefit from DXVK wrapped in dgvoodoo2
- Upstream only supports SteamOS -> probably more issues to come on linux due upstream's incompetence.

Linux support is not provided, Rocket League for linux is in BETA. -> Rocket League for Linux is garbage.
![image](https://user-images.githubusercontent.com/11302521/53983354-4e95bc80-4117-11e9-875b-23fda3b4f4ee.png)

### Research

Wine wrapped windows app?

https://appdb.winehq.org/objectManager.php?sClass=version&iId=32371 -> Seems to work ootb.

Steam is able to force windows version for proton on native linux. https://steamcommunity.com/groups/SteamClientBeta#announcements/detail/1703951108827819236

Relevant: https://github.com/ValveSoftware/Proton/issues/102

Seems to work with no problem on proton `3.16-7 Beta`, Shaders needs to be preloaded.

---

Signed-off-by: Jacob Hrbek <werifGX@gmail.com>