### PR TITLE
Update Local/Online Installer Script to handle args correctly

### DIFF
--- a/Engines/Wine/QuickScript/Local Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Local Installer Script/script.js
@@ -10,7 +10,7 @@ LocalInstallerScript.prototype = Object.create(InstallerScript.prototype);
 LocalInstallerScript.prototype.constructor = LocalInstallerScript;
 
 LocalInstallerScript.prototype.installationArgs = function (installationArgs) {
-    if (typeof args === 'string' || args instanceof String) {
+    if (typeof installationArgs === 'string' || installationArgs instanceof String) {
         this._installationArgs = [installationArgs];
     } else {
         this._installationArgs = installationArgs;

--- a/Engines/Wine/QuickScript/Local Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Local Installer Script/script.js
@@ -10,7 +10,11 @@ LocalInstallerScript.prototype = Object.create(InstallerScript.prototype);
 LocalInstallerScript.prototype.constructor = LocalInstallerScript;
 
 LocalInstallerScript.prototype.installationArgs = function (installationArgs) {
-    this._installationArgs = installationArgs;
+    if (typeof args === 'string' || args instanceof String) {
+        this._installationArgs = [installationArgs];
+    } else {
+        this._installationArgs = installationArgs;
+    }
     return this;
 };
 

--- a/Engines/Wine/QuickScript/Online Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Online Installer Script/script.js
@@ -22,7 +22,11 @@ OnlineInstallerScript.prototype.checksum = function (checksum) {
 };
 
 OnlineInstallerScript.prototype.installationArgs = function (installationArgs) {
-    this._installationArgs = installationArgs;
+    if (typeof args === 'string' || args instanceof String) {
+        this._installationArgs = [installationArgs];
+    } else {
+        this._installationArgs = installationArgs;
+    }
     return this;
 };
 
@@ -43,5 +47,5 @@ OnlineInstallerScript.prototype._installationCommand = function (wizard) {
         .to(installationFile)
         .get();
 
-    return {command: installationFile, args: [this._installationArgs]};
+    return {command: installationFile, args: this._installationArgs};
 };

--- a/Engines/Wine/QuickScript/Online Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Online Installer Script/script.js
@@ -22,7 +22,7 @@ OnlineInstallerScript.prototype.checksum = function (checksum) {
 };
 
 OnlineInstallerScript.prototype.installationArgs = function (installationArgs) {
-    if (typeof args === 'string' || args instanceof String) {
+    if (typeof installationArgs === 'string' || installationArgs instanceof String) {
         this._installationArgs = [installationArgs];
     } else {
         this._installationArgs = installationArgs;


### PR DESCRIPTION
Ensure that args are always an array internally even if only a string is passed to `installationArgs()`. Moreover, avoid that args are `[[]]` if no args have been set.