### PR TITLE
Add Uplay option for Assassin's Creed III

### DIFF
--- a/Applications/Games/Assassin's Creed III/Steam/script.js
+++ b/Applications/Games/Assassin's Creed III/Steam/script.js
@@ -4,7 +4,7 @@ include("engines.wine.verbs.dxvk");
 var installerImplementation = {
     run: function () {
         new SteamScript()
-            .name("Assassin’s Creed® III")
+            .name("Assassin’s Creed III")
             .editor("Ubisoft Montreal")
             .author("Plata")
             .appId(208480)

--- a/Applications/Games/Assassin's Creed III/Steam/script.js
+++ b/Applications/Games/Assassin's Creed III/Steam/script.js
@@ -1,17 +1,23 @@
 include("engines.wine.quick_script.steam_script");
 include("engines.wine.verbs.dxvk");
+include("engines.wine.verbs.corefonts");
+include("engines.wine.verbs.vcrun2008");
+
+// Doesn't work! - https://github.com/PhoenicisOrg/scripts/pull/967#issuecomment-499492492
 
 var installerImplementation = {
     run: function () {
         new SteamScript()
             .name("Assassin’s Creed III")
             .editor("Ubisoft Montreal")
-            .author("Plata")
+            .author("Plata, KREYREN")
             .appId(208480)
             .wineVersion(LATEST_STAGING_VERSION)
             .wineDistribution("staging")
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
+                wine.corefonts();
+                wine.vcrun2008();
             })
             .go();
     }

--- a/Applications/Games/Assassin's Creed III/Steam/script.js
+++ b/Applications/Games/Assassin's Creed III/Steam/script.js
@@ -1,4 +1,5 @@
 include("engines.wine.quick_script.steam_script");
+include("engines.wine.verbs.dxvk");
 
 var installerImplementation = {
     run: function () {
@@ -9,6 +10,9 @@ var installerImplementation = {
             .appId(208480)
             .wineVersion(LATEST_STAGING_VERSION)
             .wineDistribution("staging")
+            .preInstall(function (wine/*, wizard*/) {
+                wine.DXVK();
+            })
             .go();
     }
 };

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -1,0 +1,15 @@
+include("engines.wine.quick_script.uplay_script");
+
+var installerImplementation = {
+    run: function () {
+        new UplayScript()
+            .name("Assassin's Creed III")
+            .editor("Ubisoft, Gameloft, Ubisoft Montreal, Blue Byte, MORE")
+            .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
+            .author("KREYREN")
+            .appId(54)
+            .go();
+};
+
+/* exported Installer */
+var Installer = Java.extend(org.phoenicis.scripts.Installer, installerImplementation);

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -13,6 +13,7 @@ var installerImplementation = {
                 wine.DXVK();
             })
             .go();
+    }
 };
 
 /* exported Installer */

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -13,7 +13,6 @@ var installerImplementation = {
             .appId(54)
             .wineDistribution("staging")
             .wineVersion(LATEST_STAGING_VERSION)
-            .wineArchitecture("amd64")
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
                 wine.corefonts();

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -1,13 +1,17 @@
 include("engines.wine.quick_script.uplay_script");
+include("engines.wine.verbs.dxvk");
 
 var installerImplementation = {
     run: function () {
         new UplayScript()
-            .name("Assassin's Creed III")
+            .name("Assassin's Creed")
             .editor("Ubisoft, Gameloft, Ubisoft Montreal, Blue Byte, MORE")
             .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
             .author("KREYREN")
-            .appId(54)
+            .appId(273)
+            .preInstall(function (wine/*, wizard*/) {
+                wine.DXVK();
+            })
             .go();
 };
 

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -4,7 +4,7 @@ include("engines.wine.verbs.dxvk");
 var installerImplementation = {
     run: function () {
         new UplayScript()
-            .name("Assassin's Creed")
+            .name("Assassin's Creed III")
             .editor("Ubisoft, Gameloft, Ubisoft Montreal, Blue Byte, MORE")
             .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
             .author("KREYREN")

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -1,5 +1,7 @@
 include("engines.wine.quick_script.uplay_script");
 include("engines.wine.verbs.dxvk");
+include("engines.wine.verbs.corefonts");
+include("engines.wine.verbs.vcrun2008");
 
 var installerImplementation = {
     run: function () {
@@ -9,8 +11,12 @@ var installerImplementation = {
             .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
             .author("KREYREN")
             .appId(54)
+            .wineDistribution("staging")
+            .wineVersion(LATEST_STAGING_VERSION)
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
+                wine.corefonts();
+                wine.vcrun2008();
             })
             .go();
     }

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -3,6 +3,8 @@ include("engines.wine.verbs.dxvk");
 include("engines.wine.verbs.corefonts");
 include("engines.wine.verbs.vcrun2008");
 
+// STATUS: crash on startup
+
 var installerImplementation = {
     run: function () {
         new UplayScript()

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -13,6 +13,7 @@ var installerImplementation = {
             .appId(54)
             .wineDistribution("staging")
             .wineVersion(LATEST_STAGING_VERSION)
+            .wineArchitecture("amd64")
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
                 wine.corefonts();

--- a/Applications/Games/Assassin's Creed III/Uplay/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.js
@@ -8,7 +8,7 @@ var installerImplementation = {
             .editor("Ubisoft, Gameloft, Ubisoft Montreal, Blue Byte, MORE")
             .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
             .author("KREYREN")
-            .appId(273)
+            .appId(54)
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
             })

--- a/Applications/Games/Assassin's Creed III/Uplay/script.json
+++ b/Applications/Games/Assassin's Creed III/Uplay/script.json
@@ -1,0 +1,10 @@
+{
+    "scriptName"                 : "Uplay",
+    "id"                         : "applications.games.assassins_creed_3.uplay",
+    "compatibleOperatingSystems" : [
+        "LINUX"
+    ],
+    "testingOperatingSystems" : [],
+    "free"                    : false,
+    "requiresPatch"           : false
+}

--- a/Applications/Games/Assassin's Creed III/Uplay_proton/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay_proton/script.js
@@ -11,7 +11,8 @@ var installerImplementation = {
             .applicationHomepage("https://www.ubisoft.com/en-us/game/assassins-creed")
             .author("KREYREN")
             .appId(54)
-            .wineDistribution("proton")
+            .wineDistribution("staging")
+            .wineVersion(LATEST_STAGING_VERSION)
             .preInstall(function (wine/*, wizard*/) {
                 wine.DXVK();
                 wine.corefonts();

--- a/Applications/Games/Assassin's Creed III/Uplay_proton/script.js
+++ b/Applications/Games/Assassin's Creed III/Uplay_proton/script.js
@@ -3,6 +3,8 @@ include("engines.wine.verbs.dxvk");
 include("engines.wine.verbs.corefonts");
 include("engines.wine.verbs.vcrun2008");
 
+// STATUS: crash on startup
+
 var installerImplementation = {
     run: function () {
         new UplayScript()

--- a/Applications/Games/Assassin's Creed III/Uplay_proton/script.json
+++ b/Applications/Games/Assassin's Creed III/Uplay_proton/script.json
@@ -1,0 +1,10 @@
+{
+    "scriptName"                 : "Uplay (Proton+DXVK)",
+    "id"                         : "applications.games.assassins_creed_3.uplay_proton_dxvk",
+    "compatibleOperatingSystems" : [
+        "LINUX"
+    ],
+    "testingOperatingSystems" : [],
+    "free"                    : false,
+    "requiresPatch"           : false
+}

--- a/Applications/Games/Assassin's Creed III/application.json
+++ b/Applications/Games/Assassin's Creed III/application.json
@@ -1,5 +1,5 @@
 {
-    "name"        : "Assassin’s Creed® III",
+    "name"        : "Assassin’s Creed III",
     "id"          : "applications.games.assassins_creed_3",
     "description" : "The American Colonies, 1775. It’s a time of civil unrest and political upheaval in the Americas. As a Native American assassin fights to protect his land and his people, he will ignite the flames of a young nation’s revolution.<br>Assassin’s Creed® III takes you back to the American Revolutionary War, but not the one you’ve read about in history books..."
 }


### PR DESCRIPTION
Credit: https://github.com/Haoose/UPLAY_GAME_ID/blob/master/README.md

~~Blocked by: https://github.com/PhoenicisOrg/scripts/pull/978~~
Blocked by #982
Blocked by https://github.com/PhoenicisOrg/scripts/issues/959
Affected by https://github.com/PhoenicisOrg/scripts/issues/881

`VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/nvidia_icd.json` -> Same effect

Based on https://lutris.net/games/install/8328/view -> Corefonts and vcrun2008 are required.

Staging required https://bugs.winehq.org/show_bug.cgi?id=41181