### PR TITLE
Refactor the Quick Script Classes

### DIFF
--- a/Engines/Wine/QuickScript/Custom Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Custom Installer Script/script.js
@@ -1,14 +1,12 @@
 include("engines.wine.quick_script.installer_script");
 
-function CustomInstallerScript() {
-    InstallerScript.call(this);
+class CustomInstallerScript extends InstallerScript {
+    constructor() {
+        super();
+    }
+
+    installationCommand(installationCommand) {
+        this._installationCommand = installationCommand;
+        return this;
+    }
 }
-
-CustomInstallerScript.prototype = Object.create(InstallerScript.prototype);
-
-CustomInstallerScript.prototype.constructor = CustomInstallerScript;
-
-CustomInstallerScript.prototype.installationCommand = function (installationCommand) {
-    this._installationCommand = installationCommand;
-    return this;
-};

--- a/Engines/Wine/QuickScript/GoG Script/script.js
+++ b/Engines/Wine/QuickScript/GoG Script/script.js
@@ -3,108 +3,107 @@ include("utils.functions.net.download");
 include("engines.wine.engine.object");
 include("engines.wine.verbs.gdiplus");
 
-function GogScript() {
-    QuickScript.call(this);
-}
+class GogScript extends QuickScript {
+    constructor() {
+        super();
+    }
 
-GogScript.prototype = Object.create(QuickScript.prototype);
+    /**
+     * Sets one setup file name so that the script can fetch it from gog.com
+     * @param {string} setupFileName The setup file name
+     * @returns {GogScript} This
+     */
+    gogSetupFileName(setupFileName) {
+        this._setupFileNames = [setupFileName];
+        return this;
+    }
 
-GogScript.prototype.constructor = GogScript;
+    /**
+     * Sets the setup file(s) name so that the script can fetch it from gog.com
+     * @param {string[]} setupFileNames The setup file name(s)
+     * @returns {GogScript} This
+     */
+    gogSetupFileNames(setupFileNames) {
+        this._setupFileNames = setupFileNames;
+        return this;
+    }
 
-/**
- * Sets one setup file name so that the script can fetch it from gog.com
- * @param {string} setupFileName The setup file name
- * @returns {GogScript} This
- */
-GogScript.prototype.gogSetupFileName = function (setupFileName) {
-    this._setupFileNames = [setupFileName];
-    return this;
-}
+    /**
+     * Presents a Gog.com login window to the user, login to its account and return a token that can be used later.
+     * Stores the tocken in a parameter
+     * @param {SetupWizard} setupWizard The setupWizard to use
+     * @returns {GogScript} This
+     */
+    loginToGog(setupWizard) {
+        const browserWindow = setupWizard.createBrowser(tr("Please login to your GoG.com account so that we can download the game for you:"));
+        browserWindow.goToUrl("https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=client2");
+        browserWindow.waitForUrl("https://embed.gog.com/*");
 
-/**
- * Sets the setup file(s) name so that the script can fetch it from gog.com
- * @param {string[]} setupFileNames The setup file name(s)
- * @returns {GogScript} This
- */
-GogScript.prototype.gogSetupFileNames = function (setupFileNames) {
-    this._setupFileNames = setupFileNames;
-    return this;
-}
+        const currentUrl = browserWindow.getCurrentUrl();
+        const code = currentUrl.split("code=")[1].split("&")[0];
 
-/**
- * Presents a Gog.com login window to the user, login to its account and return a token that can be used later.
- * Stores the tocken in a parameter
- * @param {SetupWizard} setupWizard The setupWizard to use
- * @returns {GogScript} This
- */
-GogScript.prototype.loginToGog = function (setupWizard) {
-    var browserWindow = setupWizard.createBrowser(tr("Please login to your GoG.com account so that we can download the game for you:"));
-    browserWindow.goToUrl("https://auth.gog.com/auth?client_id=46899977096215655&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient&response_type=code&layout=client2");
-    browserWindow.waitForUrl("https://embed.gog.com/*");
-    var currentUrl = browserWindow.getCurrentUrl();
-    var code = currentUrl.split("code=")[1].split("&")[0];
+        const tokenUrl = "https://auth.gog.com/token?client_id=46899977096215655&client_secret=9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9&grant_type=authorization_code&code=" + code + "&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient";
+        this._token = new Downloader().url(tokenUrl).json();
+        return this;
+    }
 
-    var tokenUrl = "https://auth.gog.com/token?client_id=46899977096215655&client_secret=9d85c43b1482497dbbce61f6e4aa173a433796eeae2ca8c5f6129f2dc4de46d9&grant_type=authorization_code&code=" + code + "&redirect_uri=https%3A%2F%2Fembed.gog.com%2Fon_login_success%3Forigin%3Dclient";
-    this._token = new Downloader().url(tokenUrl).json();
-    return this;
-}
+    _downloadSetupFile(setupWizard, setupFileName, tmpDirectory) {
+        const url = "https://www.gog.com/downloads/" + setupFileName;
 
-GogScript.prototype._downloadSetupFile = function (setupWizard, setupFileName, tmpDirectory) {
-    var url = "https://www.gog.com/downloads/" + setupFileName;
+        // We set a user agent so that GoG sends the filename of the executable
+        return new Downloader()
+            .url(url)
+            .wizard(setupWizard)
+            .to(tmpDirectory)
+            .headers({
+                "Authorization": "Bearer " + this._token["access_token"],
+                "User-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0"
+            })
+            .get();
+    }
 
-    // We set a user agent so that GoG sends the filename of the executable
-    return new Downloader()
-        .url(url)
-        .wizard(setupWizard)
-        .to(tmpDirectory)
-        .headers({
-            "Authorization": "Bearer " + this._token["access_token"],
-            "User-agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:64.0) Gecko/20100101 Firefox/64.0"
-        })
-        .get();
-}
+    /**
+     * Download the setup resources in the same directory, and returns the path of the .exe
+     * @param {SetupWizard} setupWizard The setup wizard
+     * @returns {String} The .exe file entry that can be used to continue the installation
+     */
+    download(setupWizard) {
+        const setupDirectory = createTempDir();
+        var that = this;
+        let foundExecutable = null;
+        this._setupFileNames.forEach(function (setupFileName) {
+            var downloadedFile = that._downloadSetupFile(setupWizard, setupFileName, setupDirectory);
+            if (downloadedFile.endsWith(".exe")) {
+                foundExecutable = downloadedFile;
+            }
+        });
 
-/**
- * Download the setup resources in the same directory, and returns the path of the .exe
- * @param {SetupWizard} setupWizard The setup wizard
- * @returns {String} The .exe file entry that can be used to continue the installation
- */
-GogScript.prototype.download = function (setupWizard) {
-    var setupDirectory = createTempDir();
-    var that = this;
-    var foundExecutable = null;
-    this._setupFileNames.forEach(function (setupFileName) {
-        var downloadedFile = that._downloadSetupFile(setupWizard, setupFileName, setupDirectory);
-        if (downloadedFile.endsWith(".exe")) {
-            foundExecutable = downloadedFile;
-        }
-    });
+        return foundExecutable;
+    }
 
-    return foundExecutable;
-}
+    go() {
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
 
-GogScript.prototype.go = function () {
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
 
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
+        this.loginToGog(setupWizard);
+        const setupFile = this.download(setupWizard);
 
-    this.loginToGog(setupWizard);
-    var setupFile = this.download(setupWizard);
+        const wine = new Wine()
+            .wizard(setupWizard)
+            .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .create()
+            .wait();
 
-    var wine = new Wine()
-        .wizard(setupWizard)
-        .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .create()
-        .wait();
+        this._preInstall(wine, setupWizard);
 
-    this._preInstall(wine, setupWizard);
+        wine.gdiplus();
+        wine.run(setupFile, [], wine.prefixDirectory() + "/drive_c/", true, true);
 
-    wine.gdiplus();
-    wine.run(setupFile, [], wine.prefixDirectory() + "/drive_c/", true, true);
+        this._postInstall(wine, setupWizard);
 
-    this._postInstall(wine, setupWizard);
+        this._createShortcut(wine.prefix());
 
-    this._createShortcut(wine.prefix());
-
-    setupWizard.close();
+        setupWizard.close();
+    }
 }

--- a/Engines/Wine/QuickScript/Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Installer Script/script.js
@@ -4,91 +4,88 @@ include("utils.functions.filesystem.extract");
 include("utils.functions.filesystem.files");
 include("engines.wine.verbs.luna");
 
+class InstallerScript extends QuickScript {
+    constructor() {
+        super();
+    }
 
-function InstallerScript() {
-    QuickScript.call(this);
+    go() {
+        this._name = this._name || "Custom Installer";
+
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
+
+        // if no name given, ask user
+        if (this._name == "Custom Installer") {
+            this._name = setupWizard.textbox(tr("Please enter the name of your application."));
+        }
+
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
+
+        // get installation file from concrete InstallerScript implementation
+        var installationCommand = this._installationCommand(setupWizard);
+
+        var wine = new Wine()
+            .wizard(setupWizard);
+
+        // let user select wine settings if desired
+        if (this._wineUserSettings) {
+            var architectures = ["x86", "amd64"];
+            var shownArchitectures = ["x86 (recommended)", "amd64"];
+            var selectedArchitecture = setupWizard.menu(tr("Please select the wine architecture."), shownArchitectures, "x86 (recommended)");
+            this._wineArchitecture = architectures[selectedArchitecture.index];
+
+            var distributions = wine.availableDistributions(this._wineArchitecture);
+            var shownDistributions = [];
+            for (var distributionIdx in distributions) {
+                if (distributions[distributionIdx] == "upstream") {
+                    shownDistributions.push("upstream (recommended)");
+                }
+                else {
+                    shownDistributions.push(distributions[distributionIdx]);
+                }
+            }
+            var selectedDistribution = setupWizard.menu(tr("Please select the wine distribution."), shownDistributions, "upstream (recommended)");
+            this._wineDistribution = distributions[selectedDistribution.index];
+
+            var operatingSystemFetcher = Bean("operatingSystemFetcher");
+            var operatingSystem = operatingSystemFetcher.fetchCurrentOperationSystem().getWinePackage();
+            var versions = wine.availableVersions(this._wineDistribution + "-" + operatingSystem + "-" + this._wineArchitecture);
+            var shownVersions = [];
+            for (var versionIdx in versions) {
+                if (versions[versionIdx] == LATEST_STABLE_VERSION) {
+                    shownVersions.push(versions[versionIdx] + " (recommended)");
+                }
+                else {
+                    shownVersions.push(versions[versionIdx]);
+                }
+            }
+            var selectedVersion = setupWizard.menu(tr("Please select the wine version."), shownVersions, LATEST_STABLE_VERSION + " (recommended)");
+            this._wineVersion = versions[selectedVersion.index];
+        }
+
+        // setup the prefix
+        wine.prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .luna();
+
+        this._preInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in preInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        wine.run(installationCommand.command, installationCommand.args, false, true);
+
+        // if no executable given, ask user
+        if (!this._executable) {
+            this._executable = fileName(setupWizard.browse(tr("Please select the executable."), wine.prefixDirectory(), ["exe"]));
+        }
+
+        this._createShortcut(wine.prefix());
+
+        this._postInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in postInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        setupWizard.close();
+    }
 }
-
-InstallerScript.prototype = Object.create(QuickScript.prototype);
-
-InstallerScript.prototype.constructor = InstallerScript;
-
-InstallerScript.prototype.go = function () {
-    this._name = this._name || "Custom Installer";
-
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
-
-    // if no name given, ask user
-    if (this._name == "Custom Installer") {
-        this._name = setupWizard.textbox(tr("Please enter the name of your application."));
-    }
-
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
-
-    // get installation file from concrete InstallerScript implementation
-    var installationCommand = this._installationCommand(setupWizard);
-
-    var wine = new Wine()
-        .wizard(setupWizard);
-
-    // let user select wine settings if desired
-    if (this._wineUserSettings) {
-        var architectures = ["x86", "amd64"];
-        var shownArchitectures = ["x86 (recommended)", "amd64"];
-        var selectedArchitecture = setupWizard.menu(tr("Please select the wine architecture."), shownArchitectures, "x86 (recommended)");
-        this._wineArchitecture = architectures[selectedArchitecture.index];
-
-        var distributions = wine.availableDistributions(this._wineArchitecture);
-        var shownDistributions = [];
-        for (var distributionIdx in distributions) {
-            if (distributions[distributionIdx] == "upstream") {
-                shownDistributions.push("upstream (recommended)");
-            }
-            else {
-                shownDistributions.push(distributions[distributionIdx]);
-            }
-        }
-        var selectedDistribution = setupWizard.menu(tr("Please select the wine distribution."), shownDistributions, "upstream (recommended)");
-        this._wineDistribution = distributions[selectedDistribution.index];
-
-        var operatingSystemFetcher = Bean("operatingSystemFetcher");
-        var operatingSystem = operatingSystemFetcher.fetchCurrentOperationSystem().getWinePackage();
-        var versions = wine.availableVersions(this._wineDistribution + "-" + operatingSystem + "-" + this._wineArchitecture);
-        var shownVersions = [];
-        for (var versionIdx in versions) {
-            if (versions[versionIdx] == LATEST_STABLE_VERSION) {
-                shownVersions.push(versions[versionIdx] + " (recommended)");
-            }
-            else {
-                shownVersions.push(versions[versionIdx]);
-            }
-        }
-        var selectedVersion = setupWizard.menu(tr("Please select the wine version."), shownVersions, LATEST_STABLE_VERSION + " (recommended)");
-        this._wineVersion = versions[selectedVersion.index];
-    }
-
-    // setup the prefix
-    wine.prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .luna();
-
-    this._preInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in preInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    wine.run(installationCommand.command, installationCommand.args, false, true);
-
-    // if no executable given, ask user
-    if (!this._executable) {
-        this._executable = fileName(setupWizard.browse(tr("Please select the executable."), wine.prefixDirectory(), ["exe"]));
-    }
-
-    this._createShortcut(wine.prefix());
-
-    this._postInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in postInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    setupWizard.close();
-};

--- a/Engines/Wine/QuickScript/Local Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Local Installer Script/script.js
@@ -1,31 +1,33 @@
 include("engines.wine.quick_script.installer_script");
 
-function LocalInstallerScript() {
-    InstallerScript.call(this);
-    this._installationArgs = [];
-}
+class LocalInstallerScript extends InstallerScript {
+    constructor() {
+        super();
 
-LocalInstallerScript.prototype = Object.create(InstallerScript.prototype);
-
-LocalInstallerScript.prototype.constructor = LocalInstallerScript;
-
-LocalInstallerScript.prototype.installationArgs = function (installationArgs) {
-    if (typeof installationArgs === 'string' || installationArgs instanceof String) {
-        this._installationArgs = [installationArgs];
-    } else {
-        this._installationArgs = installationArgs;
+        this._installationArgs = [];
     }
-    return this;
-};
 
-LocalInstallerScript.prototype.browseMessage = function (browseMessage) {
-    this._browseMessage = browseMessage;
-    return this;
-};
+    installationArgs(installationArgs) {
+        if (typeof installationArgs === 'string' || installationArgs instanceof String) {
+            this._installationArgs = [installationArgs];
+        } else {
+            this._installationArgs = installationArgs;
+        }
+        return this;
+    }
 
-LocalInstallerScript.prototype._installationCommand = function (wizard) {
-    var browseMessage = this._browseMessage || tr("Please select the installation file.");
-    var installationFile = wizard.browse(browseMessage);
+    browseMessage(browseMessage) {
+        this._browseMessage = browseMessage;
+        return this;
+    }
 
-    return {command: installationFile, args: this._installationArgs};
-};
+    _installationCommand(wizard) {
+        const browseMessage = this._browseMessage || tr("Please select the installation file.");
+        const installationFile = wizard.browse(browseMessage);
+
+        return {
+            command: installationFile,
+            args: this._installationArgs
+        };
+    }
+}

--- a/Engines/Wine/QuickScript/Online Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Online Installer Script/script.js
@@ -1,51 +1,49 @@
 include("engines.wine.quick_script.installer_script");
 include("utils.functions.net.download");
 
+class OnlineInstallerScript extends InstallerScript {
+    constructor() {
+        super();
 
-function OnlineInstallerScript() {
-    InstallerScript.call(this);
-    this._installationArgs = [];
+        this._installationArgs = [];
+    }
+
+    url(url) {
+        this._url = url;
+        return this;
+    }
+
+    checksum(checksum) {
+        this._checksum = checksum;
+        return this;
+    }
+
+    installationArgs(installationArgs) {
+        if (typeof installationArgs === 'string' || installationArgs instanceof String) {
+            this._installationArgs = [installationArgs];
+        } else {
+            this._installationArgs = installationArgs;
+        }
+        return this;
+    }
+
+    _installationCommand(wizard) {
+        // if no URL given, ask user
+        if (!this._url) {
+            this._url = wizard.textbox(tr("Please select the download URL."));
+        }
+
+        // get correct extension depending on URL
+        var extension = this._url.split('.').pop();
+        var installationFile = createTempFile(extension);
+
+        new Downloader()
+            .wizard(wizard)
+            .url(this._url)
+            .checksum(this._checksum)
+            .to(installationFile)
+            .get();
+
+        return { command: installationFile, args: this._installationArgs };
+    }
 }
-
-OnlineInstallerScript.prototype = Object.create(InstallerScript.prototype);
-
-OnlineInstallerScript.prototype.constructor = OnlineInstallerScript;
-
-OnlineInstallerScript.prototype.url = function (url) {
-    this._url = url;
-    return this;
-};
-
-OnlineInstallerScript.prototype.checksum = function (checksum) {
-    this._checksum = checksum;
-    return this;
-};
-
-OnlineInstallerScript.prototype.installationArgs = function (installationArgs) {
-    if (typeof installationArgs === 'string' || installationArgs instanceof String) {
-        this._installationArgs = [installationArgs];
-    } else {
-        this._installationArgs = installationArgs;
-    }
-    return this;
-};
-
-OnlineInstallerScript.prototype._installationCommand = function (wizard) {
-    // if no URL given, ask user
-    if (!this._url) {
-        this._url = wizard.textbox(tr("Please select the download URL."));
-    }
-
-    // get correct extension depending on URL
-    var extension = this._url.split('.').pop();
-    var installationFile = createTempFile(extension);
-
-    new Downloader()
-        .wizard(wizard)
-        .url(this._url)
-        .checksum(this._checksum)
-        .to(installationFile)
-        .get();
-
-    return {command: installationFile, args: this._installationArgs};
-};

--- a/Engines/Wine/QuickScript/Origin Script/script.js
+++ b/Engines/Wine/QuickScript/Origin Script/script.js
@@ -4,69 +4,65 @@ include("engines.wine.engine.object");
 include("utils.functions.filesystem.files");
 include("engines.wine.verbs.luna");
 
+class OriginScript extends QuickScript {
+    constructor() {
+        super();
 
-function OriginScript() {
-    QuickScript.call(this);
-
-    this._executable = "Origin.exe";
-    this._category = "Games";
-}
-
-OriginScript.prototype = Object.create(QuickScript.prototype);
-
-OriginScript.prototype.constructor = OriginScript;
-
-OriginScript.prototype.appId = function (appId) {
-    this._appId = appId;
-    return this;
-};
-
-OriginScript.prototype.go = function () {
-
-    // default executable args if not specified
-    if (!this._executableArgs) {
-        this._executableArgs = ["origin://launchgame/" + this._appId];
+        this._executable = "Origin.exe";
+        this._category = "Games";
     }
 
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
+    appId(appId) {
+        this._appId = appId;
+        return this;
+    }
 
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
+    go() {
+        // default executable args if not specified
+        if (!this._executableArgs) {
+            this._executableArgs = ["origin://launchgame/" + this._appId];
+        }
 
-    var tempFile = createTempFile("exe");
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
 
-    new Downloader()
-        .wizard(setupWizard)
-        .url("https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe")
-        .to(tempFile)
-        .get();
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
 
-    var wine = new Wine()
-        .wizard(setupWizard)
-        .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .luna();
+        const tempFile = createTempFile("exe");
 
-    //Origin does not have an install command
-    setupWizard.message(tr("Download \"{0}\" in Origin and shut it down once \"{0}\" is installed", this._name));
-    wine.run(tempFile, [], null, false, true);
+        new Downloader()
+            .wizard(setupWizard)
+            .url("https://origin-a.akamaihd.net/Origin-Client-Download/origin/live/OriginThinSetup.exe")
+            .to(tempFile)
+            .get();
 
-    // wait until Origin and Wine are closed
-    wine.wait();
+        const wine = new Wine()
+            .wizard(setupWizard)
+            .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .luna();
 
-    // Origin installation has finished
-    setupWizard.wait(tr("Please wait..."));
+        //Origin does not have an install command
+        setupWizard.message(tr("Download \"{0}\" in Origin and shut it down once \"{0}\" is installed", this._name));
+        wine.run(tempFile, [], null, false, true);
 
-    this._preInstall(wine, setupWizard);
+        // wait until Origin and Wine are closed
+        wine.wait();
 
-    // back to generic wait (might have been changed in preInstall)
-    setupWizard.wait(tr("Please wait..."));
+        // Origin installation has finished
+        setupWizard.wait(tr("Please wait..."));
 
-    this._postInstall(wine, setupWizard);
+        this._preInstall(wine, setupWizard);
 
-    // create shortcut after installation (if executable is specified, it does not exist earlier)
-    this._createShortcut(wine.prefix());
+        // back to generic wait (might have been changed in preInstall)
+        setupWizard.wait(tr("Please wait..."));
 
-    // back to generic wait (might have been changed in postInstall)
-    setupWizard.wait(tr("Please wait..."));
+        this._postInstall(wine, setupWizard);
 
-    setupWizard.close();
-};
+        // create shortcut after installation (if executable is specified, it does not exist earlier)
+        this._createShortcut(wine.prefix());
+
+        // back to generic wait (might have been changed in postInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        setupWizard.close();
+    }
+}

--- a/Engines/Wine/QuickScript/Quick Script/script.js
+++ b/Engines/Wine/QuickScript/Quick Script/script.js
@@ -1,132 +1,136 @@
 include("engines.wine.shortcuts.wine");
 
-function QuickScript() {
-    this._wineVersion = LATEST_STABLE_VERSION;
-    this._wineArchitecture = "x86";
-    this._wineDistribution = "upstream";
+class QuickScript {
+    constructor() {
+        this._wineVersion = LATEST_STABLE_VERSION;
+        this._wineArchitecture = "x86";
+        this._wineDistribution = "upstream";
+        this._wineUserSettings = false;
 
-    this._type = "Applications";
+        this._type = "Applications";
 
-    // by default do nothing in post install
-    this._postInstall = function () {};
-    this._preInstall = function () {};
-    this._wineUserSettings = false;
+        // by default do nothing in post install
+        this._postInstall = function () { };
+        this._preInstall = function () { };
 
-    var appsManager = Bean("repositoryManager");
-    var application = appsManager.getApplication([TYPE_ID, CATEGORY_ID, APPLICATION_ID]);
-    this._miniature = java.util.Optional.empty();
-    if (application) {
-        this._miniature = application.getMainMiniature();
+        const appsManager = Bean("repositoryManager");
+        const application = appsManager.getApplication([TYPE_ID, CATEGORY_ID, APPLICATION_ID]);
+
+        this._miniature = java.util.Optional.empty();
+        if (application) {
+            this._miniature = application.getMainMiniature();
+        }
+    }
+
+    name(name) {
+        this._name = name;
+        return this;
+    }
+
+    editor(editor) {
+        this._editor = editor;
+        return this;
+    }
+
+    applicationHomepage(applicationHomepage) {
+        this._applicationHomepage = applicationHomepage;
+        return this;
+    }
+
+    author(author) {
+        this._author = author;
+        return this;
+    }
+
+    type(type) {
+        this._type = type;
+        return this;
+    }
+
+    category(category) {
+        this._category = category;
+        return this;
+    }
+
+    /**
+     * get/set miniature (for the installation and the shortcut)
+     * @param {URI} [miniature] path to the miniature file
+     */
+    miniature(miniature) {
+        // get
+        if (arguments.length == 0) {
+            return this._miniature;
+        }
+
+        // set
+        this._miniature = java.util.Optional.of(miniature);
+        return this;
+    }
+
+    /**
+     * set executable
+     * @param executable executable without path (e.g. "Steam.exe")
+     * @param args use array (e.g. ["-applaunch", 409160])
+     */
+    executable(executable, args) {
+        this._executable = executable;
+        this._executableArgs = typeof args !== 'undefined' ? args : "";
+        return this;
+    }
+
+    wineArchitecture(wineArchitecture) {
+        this._wineArchitecture = wineArchitecture;
+        return this;
+    }
+
+    wineDistribution(wineDistribution) {
+        this._wineDistribution = wineDistribution;
+        return this;
+    }
+
+    wineVersion(wineVersion) {
+        this._wineVersion = wineVersion;
+        return this;
+    }
+
+    wineUserSettings(wineUserSettings) {
+        // get
+        if (arguments.length == 0) {
+            return this._wineUserSettings;
+        }
+
+        // set
+        this._wineUserSettings = wineUserSettings;
+        return this;
+    }
+
+    postInstall(postInstall) {
+        this._postInstall = postInstall;
+        return this;
+    }
+
+    preInstall(preInstall) {
+        this._preInstall = preInstall;
+        return this;
+    }
+
+    /**
+     * creates shortcut
+     * @param {string} [prefix] prefix name
+     */
+    _createShortcut(prefix) {
+        const shortcut = new WineShortcut()
+            .name(this._name)
+            .type(this._type)
+            .category(this._category)
+            .prefix(prefix)
+            .search(this._executable)
+            .arguments(this._executableArgs);
+
+        if (this.miniature().isPresent()) {
+            shortcut.miniature(this.miniature().get())
+        }
+
+        shortcut.create();
     }
 }
-
-QuickScript.prototype.name = function (name) {
-    this._name = name;
-    return this;
-};
-
-QuickScript.prototype.editor = function (editor) {
-    this._editor = editor;
-    return this;
-};
-
-QuickScript.prototype.applicationHomepage = function (applicationHomepage) {
-    this._applicationHomepage = applicationHomepage;
-    return this;
-};
-
-QuickScript.prototype.author = function (author) {
-    this._author = author;
-    return this;
-};
-
-QuickScript.prototype.type = function (type) {
-    this._type = type;
-    return this;
-};
-
-QuickScript.prototype.category = function (category) {
-    this._category = category;
-    return this;
-};
-
-/**
- * get/set miniature (for the installation and the shortcut)
- * @param {URI} [miniature] path to the miniature file
- */
-QuickScript.prototype.miniature = function (miniature) {
-    // get
-    if (arguments.length == 0) {
-        return this._miniature;
-    }
-
-    // set
-    this._miniature = java.util.Optional.of(miniature);
-    return this;
-};
-
-/**
- * set executable
- * @param executable executable without path (e.g. "Steam.exe")
- * @param args use array (e.g. ["-applaunch", 409160])
- */
-QuickScript.prototype.executable = function (executable, args) {
-    this._executable = executable;
-    this._executableArgs = typeof args !== 'undefined' ? args : "";
-    return this;
-};
-
-QuickScript.prototype.wineArchitecture = function (wineArchitecture) {
-    this._wineArchitecture = wineArchitecture;
-    return this;
-};
-
-QuickScript.prototype.wineDistribution = function (wineDistribution) {
-    this._wineDistribution = wineDistribution;
-    return this;
-};
-
-QuickScript.prototype.wineVersion = function (wineVersion) {
-    this._wineVersion = wineVersion;
-    return this;
-};
-
-QuickScript.prototype.wineUserSettings = function (wineUserSettings) {
-    // get
-    if (arguments.length == 0) {
-        return this._wineUserSettings;
-    }
-
-    // set
-    this._wineUserSettings = wineUserSettings;
-    return this;
-};
-
-QuickScript.prototype.postInstall = function (postInstall) {
-    this._postInstall = postInstall;
-    return this;
-};
-
-QuickScript.prototype.preInstall = function (preInstall) {
-    this._preInstall = preInstall;
-    return this;
-};
-
-/**
- * creates shortcut
- * @param {string} [prefix] prefix name
- */
-QuickScript.prototype._createShortcut = function (prefix) {
-    var shortcut = new WineShortcut()
-        .name(this._name)
-        .type(this._type)
-        .category(this._category)
-        .prefix(prefix)
-        .search(this._executable)
-        .arguments(this._executableArgs);
-
-    if (this.miniature().isPresent()) {
-        shortcut.miniature(this.miniature().get())
-    }
-    shortcut.create();
-};

--- a/Engines/Wine/QuickScript/Steam Script/script.js
+++ b/Engines/Wine/QuickScript/Steam Script/script.js
@@ -8,185 +8,179 @@ include("engines.wine.verbs.luna");
 include("engines.wine.verbs.corefonts");
 include("engines.wine.plugins.windows_version");
 
+class SteamScript extends QuickScript {
+    constructor() {
+        super();
 
-function SteamScript() {
-    QuickScript.call(this);
+        this._executable = "Steam.exe";
+        this._category = "Games";
+        this._gameOverlay = true;
+    }
 
-    this._executable = "Steam.exe";
-    this._category = "Games";
-    this._gameOverlay = true;
+    appId(appId) {
+        this._appId = appId;
+        return this;
+    }
+
+    gameOverlay(gameOverlay) {
+        // get
+        if (arguments.length == 0) {
+            return this._gameOverlay;
+        }
+
+        // set
+        this._gameOverlay = gameOverlay;
+        return this;
+    }
+
+    manifest(wine) {
+        if (!this._manifest) {
+            // cache manifest path (will not change during the installation)
+            this._manifest = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/steamapps/appmanifest_" + this._appId + ".acf";
+        }
+        return this._manifest;
+    }
+
+    downloadStarted(wine) {
+        if (fileExists(this.manifest(wine))) {
+            const manifest = cat(this.manifest(wine));
+            const state = Number(manifest.match(/\"StateFlags\"\s+\"(\d+)\"/)[1]);
+            return state == 1026 || state == 1042 || state == 1062 || state == 1030;
+        }
+        else {
+            return false;
+        }
+    }
+
+    downloadFinished(wine) {
+        // check if download already finished (download folder has been deleted)
+        if (fileExists(this.manifest(wine))) {
+            const manifest = cat(this.manifest(wine));
+            const state = Number(manifest.match(/\"StateFlags\"\s+\"(\d+)\"/)[1]);
+            return state != 1026 && state != 1042 && state != 1062 && state != 1030;
+        }
+        else {
+            return false;
+        }
+    }
+
+    configVdf(wine) {
+        if (!this._configVdf) {
+            // cache config.vdf path (will not change during the installation)
+            this._configVdf = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/config/config.vdf";
+        }
+        return this._configVdf;
+    }
+
+    // Fix for the "content server unavailable" error (Wine bug 45329)
+    fixCertificateIssue(wine) {
+        const steamConfigFile = this.configVdf(wine);
+        const steamConfig = cat(steamConfigFile);
+        const cmPos = steamConfig.indexOf("\"CM\"");
+        const csConfig = "\"CS\" \"valve511.steamcontent.com;valve501.steamcontent.com;valve517.steamcontent.com;valve557.steamcontent.com;valve513.steamcontent.com;valve535.steamcontent.com;valve546.steamcontent.com;valve538.steamcontent.com;valve536.steamcontent.com;valve530.steamcontent.com;valve559.steamcontent.com;valve545.steamcontent.com;valve518.steamcontent.com;valve548.steamcontent.com;valve555.steamcontent.com;valve556.steamcontent.com;valve506.steamcontent.com;valve544.steamcontent.com;valve525.steamcontent.com;valve567.steamcontent.com;valve521.steamcontent.com;valve510.steamcontent.com;valve542.steamcontent.com;valve519.steamcontent.com;valve526.steamcontent.com;valve504.steamcontent.com;valve500.steamcontent.com;valve554.steamcontent.com;valve562.steamcontent.com;valve524.steamcontent.com;valve502.steamcontent.com;valve505.steamcontent.com;valve547.steamcontent.com;valve560.steamcontent.com;valve503.steamcontent.com;valve507.steamcontent.com;valve553.steamcontent.com;valve520.steamcontent.com;valve550.steamcontent.com;valve531.steamcontent.com;valve558.steamcontent.com;valve552.steamcontent.com;valve563.steamcontent.com;valve540.steamcontent.com;valve541.steamcontent.com;valve537.steamcontent.com;valve528.steamcontent.com;valve523.steamcontent.com;valve512.steamcontent.com;valve532.steamcontent.com;valve561.steamcontent.com;valve549.steamcontent.com;valve522.steamcontent.com;valve514.steamcontent.com;valve551.steamcontent.com;valve564.steamcontent.com;valve543.steamcontent.com;valve565.steamcontent.com;valve529.steamcontent.com;valve539.steamcontent.com;valve566.steamcontent.com;valve165.steamcontent.com;valve959.steamcontent.com;valve164.steamcontent.com;valve1611.steamcontent.com;valve1601.steamcontent.com;valve1617.steamcontent.com;valve1603.steamcontent.com;valve1602.steamcontent.com;valve1610.steamcontent.com;valve1615.steamcontent.com;valve909.steamcontent.com;valve900.steamcontent.com;valve905.steamcontent.com;valve954.steamcontent.com;valve955.steamcontent.com;valve1612.steamcontent.com;valve1607.steamcontent.com;valve1608.steamcontent.com;valve1618.steamcontent.com;valve1619.steamcontent.com;valve1606.steamcontent.com;valve1605.steamcontent.com;valve1609.steamcontent.com;valve907.steamcontent.com;valve901.steamcontent.com;valve902.steamcontent.com;valve1604.steamcontent.com;valve908.steamcontent.com;valve950.steamcontent.com;valve957.steamcontent.com;valve903.steamcontent.com;valve1614.steamcontent.com;valve904.steamcontent.com;valve952.steamcontent.com;valve1616.steamcontent.com;valve1613.steamcontent.com;valve958.steamcontent.com;valve956.steamcontent.com;valve906.steamcontent.com\"\n";
+        const newSteamConfig = steamConfig.slice(0, cmPos) + csConfig + steamConfig.slice(cmPos);
+        writeToFile(steamConfigFile, newSteamConfig)
+    }
+
+    go() {
+        // default application homepage if not specified
+        if (!this._applicationHomepage) {
+            this._applicationHomepage = "https://store.steampowered.com/app/" + this._appId;
+        }
+
+        // default executable args if not specified
+        if (!this._executableArgs) {
+            this._executableArgs = ["-no-cef-sandbox", "-silent", "-applaunch", this._appId];
+        }
+
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
+
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
+
+        const tempFile = createTempFile("exe");
+
+        new Downloader()
+            .wizard(setupWizard)
+            .url("https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe")
+            .checksum("4b1b85ec2499a4ce07c89609b256923a4fc479e5")
+            .to(tempFile)
+            .get();
+
+        const wine = new Wine()
+            .wizard(setupWizard)
+            .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .luna();
+
+        wine.corefonts();
+
+        // Steam must be started once such that config.vdf is created (see fixCertificateIssue())
+        setupWizard.wait(tr("Please follow the steps of the Steam setup. Then, wait until Steam is updated, log in and finally close Steam completely so the installation of \"{0}\" can continue.", this._name));
+        wine.run(tempFile, [], null, false, true);
+
+        // Set windows environment for executable that needs it
+        wine.setOsForApplication().set("steam.exe", "winxp").do();
+        wine.setOsForApplication().set("steamwebhelper.exe", "winxp").do();
+
+        // Fix for Uplay games that are executed on steam
+        wine.setOsForApplication().set("upc.exe", "winvista").do();
+        wine.setOsForApplication().set("UbisoftGameLauncher.exe", "winvista").do();
+
+        // ensure that Steam is running (user might have unchecked "run Steam after installation finished")
+        wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", ["steam://nav/games"], false);
+
+        // wait until config.vdf exists
+        while (!fileExists(this.configVdf(wine))) {
+            java.lang.Thread.sleep(1000);
+        }
+
+        // wait until Steam and Wine are closed
+        wine.wait();
+
+        this.fixCertificateIssue(wine);
+
+        // Steam installation has finished
+        setupWizard.wait(tr("Please wait..."));
+
+        this._preInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in preInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", ["steam://install/" + this._appId], false);
+
+        setupWizard.wait(tr("Please wait until Steam has finished the download..."));
+
+        // wait until download started
+        while (!this.downloadStarted(wine)) {
+            java.lang.Thread.sleep(100);
+        }
+
+        // make sure download is finished
+        while (!this.downloadFinished(wine)) {
+            java.lang.Thread.sleep(1000);
+        }
+
+        // close Steam
+        wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", "-shutdown", true);
+
+        // back to generic wait
+        setupWizard.wait(tr("Please wait..."));
+
+        // create shortcut after installation (if executable is specified, it does not exist earlier)
+        this._createShortcut(wine.prefix());
+
+        this._postInstall(wine, setupWizard);
+
+        // deactivate game overlay if desired
+        if (!this._gameOverlay) {
+            wine.overrideDLL()
+                .set("", ["gameoverlayrenderer"])
+                .do();
+        }
+
+        // back to generic wait (might have been changed in postInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        setupWizard.close();
+    }
 }
-
-SteamScript.prototype = Object.create(QuickScript.prototype);
-
-SteamScript.prototype.constructor = SteamScript;
-
-SteamScript.prototype.appId = function (appId) {
-    this._appId = appId;
-    return this;
-};
-
-SteamScript.prototype.gameOverlay = function (gameOverlay) {
-    // get
-    if (arguments.length == 0) {
-        return this._gameOverlay;
-    }
-
-    // set
-    this._gameOverlay = gameOverlay;
-    return this;
-};
-
-SteamScript.prototype.manifest = function (wine) {
-    if (!this._manifest) {
-        // cache manifest path (will not change during the installation)
-        this._manifest = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/steamapps/appmanifest_" + this._appId + ".acf";
-    }
-    return this._manifest;
-};
-
-SteamScript.prototype.downloadStarted = function (wine) {
-    if (fileExists(this.manifest(wine)))
-    {
-        var manifest = cat(this.manifest(wine));
-        var state = Number(manifest.match(/\"StateFlags\"\s+\"(\d+)\"/)[1]);
-        return state == 1026 || state == 1042 || state == 1062 || state == 1030;
-    }
-    else
-    {
-        return false;
-    }
-};
-
-SteamScript.prototype.downloadFinished = function (wine) {
-    // check if download already finished (download folder has been deleted)
-    if (fileExists(this.manifest(wine)))
-    {
-        var manifest = cat(this.manifest(wine));
-        var state = Number(manifest.match(/\"StateFlags\"\s+\"(\d+)\"/)[1]);
-        return state != 1026 && state != 1042 && state != 1062 && state != 1030;
-    }
-    else
-    {
-        return false;
-    }
-};
-
-SteamScript.prototype.configVdf = function (wine) {
-    if (!this._configVdf) {
-        // cache config.vdf path (will not change during the installation)
-        this._configVdf = wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Steam/config/config.vdf";
-    }
-    return this._configVdf;
-};
-
-// Fix for the "content server unavailable" error (Wine bug 45329)
-SteamScript.prototype.fixCertificateIssue = function (wine){
-    var steamConfigFile = this.configVdf(wine);
-    var steamConfig = cat(steamConfigFile);
-    var cmPos = steamConfig.indexOf("\"CM\"");
-    var csConfig = "\"CS\" \"valve511.steamcontent.com;valve501.steamcontent.com;valve517.steamcontent.com;valve557.steamcontent.com;valve513.steamcontent.com;valve535.steamcontent.com;valve546.steamcontent.com;valve538.steamcontent.com;valve536.steamcontent.com;valve530.steamcontent.com;valve559.steamcontent.com;valve545.steamcontent.com;valve518.steamcontent.com;valve548.steamcontent.com;valve555.steamcontent.com;valve556.steamcontent.com;valve506.steamcontent.com;valve544.steamcontent.com;valve525.steamcontent.com;valve567.steamcontent.com;valve521.steamcontent.com;valve510.steamcontent.com;valve542.steamcontent.com;valve519.steamcontent.com;valve526.steamcontent.com;valve504.steamcontent.com;valve500.steamcontent.com;valve554.steamcontent.com;valve562.steamcontent.com;valve524.steamcontent.com;valve502.steamcontent.com;valve505.steamcontent.com;valve547.steamcontent.com;valve560.steamcontent.com;valve503.steamcontent.com;valve507.steamcontent.com;valve553.steamcontent.com;valve520.steamcontent.com;valve550.steamcontent.com;valve531.steamcontent.com;valve558.steamcontent.com;valve552.steamcontent.com;valve563.steamcontent.com;valve540.steamcontent.com;valve541.steamcontent.com;valve537.steamcontent.com;valve528.steamcontent.com;valve523.steamcontent.com;valve512.steamcontent.com;valve532.steamcontent.com;valve561.steamcontent.com;valve549.steamcontent.com;valve522.steamcontent.com;valve514.steamcontent.com;valve551.steamcontent.com;valve564.steamcontent.com;valve543.steamcontent.com;valve565.steamcontent.com;valve529.steamcontent.com;valve539.steamcontent.com;valve566.steamcontent.com;valve165.steamcontent.com;valve959.steamcontent.com;valve164.steamcontent.com;valve1611.steamcontent.com;valve1601.steamcontent.com;valve1617.steamcontent.com;valve1603.steamcontent.com;valve1602.steamcontent.com;valve1610.steamcontent.com;valve1615.steamcontent.com;valve909.steamcontent.com;valve900.steamcontent.com;valve905.steamcontent.com;valve954.steamcontent.com;valve955.steamcontent.com;valve1612.steamcontent.com;valve1607.steamcontent.com;valve1608.steamcontent.com;valve1618.steamcontent.com;valve1619.steamcontent.com;valve1606.steamcontent.com;valve1605.steamcontent.com;valve1609.steamcontent.com;valve907.steamcontent.com;valve901.steamcontent.com;valve902.steamcontent.com;valve1604.steamcontent.com;valve908.steamcontent.com;valve950.steamcontent.com;valve957.steamcontent.com;valve903.steamcontent.com;valve1614.steamcontent.com;valve904.steamcontent.com;valve952.steamcontent.com;valve1616.steamcontent.com;valve1613.steamcontent.com;valve958.steamcontent.com;valve956.steamcontent.com;valve906.steamcontent.com\"\n";
-    var newSteamConfig = steamConfig.slice(0, cmPos) + csConfig + steamConfig.slice(cmPos);
-    writeToFile(steamConfigFile, newSteamConfig)
-}
-
-SteamScript.prototype.go = function () {
-    // default application homepage if not specified
-    if (!this._applicationHomepage) {
-        this._applicationHomepage = "https://store.steampowered.com/app/" + this._appId;
-    }
-
-    // default executable args if not specified
-    if (!this._executableArgs) {
-        this._executableArgs = ["-no-cef-sandbox", "-silent", "-applaunch", this._appId];
-    }
-
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
-
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
-
-    var tempFile = createTempFile("exe");
-
-    new Downloader()
-        .wizard(setupWizard)
-        .url("https://steamcdn-a.akamaihd.net/client/installer/SteamSetup.exe")
-        .checksum("4b1b85ec2499a4ce07c89609b256923a4fc479e5")
-        .to(tempFile)
-        .get();
-
-    var wine = new Wine()
-        .wizard(setupWizard)
-        .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .luna();
-    wine.corefonts();
-
-    // Steam must be started once such that config.vdf is created (see fixCertificateIssue())
-    setupWizard.wait(tr("Please follow the steps of the Steam setup. Then, wait until Steam is updated, log in and finally close Steam completely so the installation of \"{0}\" can continue.", this._name));
-    wine.run(tempFile, [], null, false, true);
-
-    // Set windows environment for executable that needs it
-    wine.setOsForApplication().set("steam.exe", "winxp").do();
-    wine.setOsForApplication().set("steamwebhelper.exe", "winxp").do();
-
-    // Fix for Uplay games that are executed on steam
-    wine.setOsForApplication().set("upc.exe", "winvista").do();
-    wine.setOsForApplication().set("UbisoftGameLauncher.exe", "winvista").do();
-
-    // ensure that Steam is running (user might have unchecked "run Steam after installation finished")
-    wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", ["steam://nav/games"], false);
-
-    // wait until config.vdf exists
-    while (!fileExists(this.configVdf(wine))) {
-        java.lang.Thread.sleep(1000);
-    }
-
-    // wait until Steam and Wine are closed
-    wine.wait();
-
-    this.fixCertificateIssue(wine);
-
-    // Steam installation has finished
-    setupWizard.wait(tr("Please wait..."));
-
-    this._preInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in preInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", ["steam://install/" + this._appId], false);
-
-    setupWizard.wait(tr("Please wait until Steam has finished the download..."));
-
-    // wait until download started
-    while (!this.downloadStarted(wine)) {
-        java.lang.Thread.sleep(100);
-    }
-
-    // make sure download is finished
-    while (!this.downloadFinished(wine)) {
-        java.lang.Thread.sleep(1000);
-    }
-
-    // close Steam
-    wine.runInsidePrefix(wine.programFiles() + "/Steam/Steam.exe", "-shutdown", true);
-
-    // back to generic wait
-    setupWizard.wait(tr("Please wait..."));
-
-    // create shortcut after installation (if executable is specified, it does not exist earlier)
-    this._createShortcut(wine.prefix());
-
-    this._postInstall(wine, setupWizard);
-
-    // deactivate game overlay if desired
-    if (!this._gameOverlay) {
-        wine.overrideDLL()
-            .set("", ["gameoverlayrenderer"])
-            .do();
-    }
-
-    // back to generic wait (might have been changed in postInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    setupWizard.close();
-};

--- a/Engines/Wine/QuickScript/Uplay Script/script.js
+++ b/Engines/Wine/QuickScript/Uplay Script/script.js
@@ -7,90 +7,88 @@ include("engines.wine.verbs.luna");
 include("engines.wine.verbs.corefonts");
 include("engines.wine.plugins.windows_version");
 
-function UplayScript() {
-    QuickScript.call(this);
+class UplayScript extends QuickScript {
+    constructor() {
+        super();
 
-    this._executable = "Uplay.exe";
-    this._category = "Games";
-    this._gameOverlay = true;
+        this._executable = "Uplay.exe";
+        this._category = "Games";
+        this._gameOverlay = true;
+    }
+
+    appId(appId) {
+        this._appId = appId;
+        return this;
+    }
+
+    downloadStarted(wine) {
+        return fileExists(wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/data/" + this._appId + "/manifests");
+    }
+
+    downloadFinished(wine) {
+        return !fileExists(wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/data/" + this._appId + "/manifests");
+    }
+
+    go() {
+        // default executable args if not specified
+        if (!this._executableArgs) {
+            this._executableArgs = ["uplay://launch/" + this._appId + "/0"];
+        }
+
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
+
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
+
+        const tempFile = createTempFile("exe");
+
+        new Downloader()
+            .wizard(setupWizard)
+            .url("https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UplayInstaller.exe")
+            .to(tempFile)
+            .get();
+
+        const wine = new Wine()
+            .wizard(setupWizard)
+            .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .luna();
+
+        wine.corefonts();
+
+        setupWizard.message(tr("Please ensure that winbind is installed before you continue."));
+        setupWizard.wait(tr("Please follow the steps of the Uplay setup.\n\nUncheck \"Run Uplay\" or close Uplay completely after the setup so that the installation of \"{0}\" can continue.", this._name));
+        wine.run(tempFile, [], null, false, true);
+
+        wine.setOsForApplication().set("upc.exe", "winvista").do();
+        wine.setOsForApplication().set("UbisoftGameLauncher.exe", "winvista").do();
+
+        // Uplay installation has finished
+        setupWizard.wait(tr("Please wait..."));
+
+        this._preInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in preInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        this._createShortcut(wine.prefix());
+
+        wine.runInsidePrefix(wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/Uplay.exe", ["uplay://launch/" + this._appId + "/0"], true);
+
+        // wait until download is finished
+        setupWizard.wait(tr("Please wait until Uplay has finished the download..."));
+        while (!this.downloadStarted(wine)) {
+            java.lang.Thread.sleep(100);
+        }
+        while (!this.downloadFinished(wine)) {
+            java.lang.Thread.sleep(1000);
+        }
+
+        setupWizard.message(tr("Please close Uplay."));
+
+        this._postInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in postInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        setupWizard.close();
+    }
 }
-
-UplayScript.prototype = Object.create(QuickScript.prototype);
-
-UplayScript.prototype.constructor = UplayScript;
-
-UplayScript.prototype.appId = function (appId) {
-    this._appId = appId;
-    return this;
-};
-
-UplayScript.prototype.downloadStarted = function (wine) {
-    return fileExists(wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/data/" + this._appId + "/manifests");
-};
-
-UplayScript.prototype.downloadFinished = function (wine) {
-    return !fileExists(wine.prefixDirectory() + "/drive_c/" + wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/data/" + this._appId + "/manifests");
-};
-
-UplayScript.prototype.go = function () {
-    // default executable args if not specified
-    if (!this._executableArgs) {
-        this._executableArgs = ["uplay://launch/" + this._appId + "/0"];
-    }
-
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
-
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
-
-    var tempFile = createTempFile("exe");
-
-    new Downloader()
-        .wizard(setupWizard)
-        .url("https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UplayInstaller.exe")
-        .to(tempFile)
-        .get();
-
-    var wine = new Wine()
-        .wizard(setupWizard)
-        .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .luna();
-
-    wine.corefonts();
-
-    setupWizard.message(tr("Please ensure that winbind is installed before you continue."));
-    setupWizard.wait(tr("Please follow the steps of the Uplay setup.\n\nUncheck \"Run Uplay\" or close Uplay completely after the setup so that the installation of \"{0}\" can continue.", this._name));
-    wine.run(tempFile, [], null, false, true);
-
-    wine.setOsForApplication().set("upc.exe", "winvista").do();
-    wine.setOsForApplication().set("UbisoftGameLauncher.exe", "winvista").do();
-
-    // Uplay installation has finished
-    setupWizard.wait(tr("Please wait..."));
-
-    this._preInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in preInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    this._createShortcut(wine.prefix());
-
-    wine.runInsidePrefix(wine.programFiles() + "/Ubisoft/Ubisoft Game Launcher/Uplay.exe", ["uplay://launch/" + this._appId + "/0"], true);
-
-    // wait until download is finished
-    setupWizard.wait(tr("Please wait until Uplay has finished the download..."));
-    while (!this.downloadStarted(wine)) {
-        java.lang.Thread.sleep(100);
-    }
-    while (!this.downloadFinished(wine)) {
-        java.lang.Thread.sleep(1000);
-    }
-
-    setupWizard.message(tr("Please close Uplay."));
-
-    this._postInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in postInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    setupWizard.close();
-};

--- a/Engines/Wine/QuickScript/Zip Script/script.js
+++ b/Engines/Wine/QuickScript/Zip Script/script.js
@@ -4,67 +4,64 @@ include("engines.wine.engine.object");
 include("utils.functions.filesystem.extract");
 include("engines.wine.verbs.luna");
 
-
-function ZipScript() {
-    QuickScript.call(this);
-}
-
-ZipScript.prototype = Object.create(QuickScript.prototype);
-
-ZipScript.prototype.constructor = ZipScript;
-
-ZipScript.prototype.url = function (url) {
-    this._url = url;
-    return this;
-};
-
-ZipScript.prototype.checksum = function (checksum) {
-    this._checksum = checksum;
-    return this;
-};
-
-ZipScript.prototype.go = function () {
-    var setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
-
-    setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
-
-    var wine = new Wine()
-        .wizard(setupWizard)
-        .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
-        .create()
-        .luna()
-        .wait();
-
-    this._preInstall(wine, setupWizard);
-
-    // back to generic wait (might have been changed in preInstall)
-    setupWizard.wait(tr("Please wait..."));
-
-    var archive = "";
-    if (!this._url) {
-        archive = setupWizard.browse(tr("Please select the .zip file."), wine.prefixDirectory(), ["zip"]);
-    } else {
-        archive = wine.prefixDirectory() + "/drive_c/archive.zip";
-        new Downloader()
-            .wizard(setupWizard)
-            .url(this._url)
-            .checksum(this._checksum)
-            .to(archive)
-            .get();
+class ZipScript extends QuickScript {
+    constructor() {
+        super();
     }
 
-    new Extractor()
-        .wizard(setupWizard)
-        .archive(archive)
-        .to(wine.prefixDirectory() + "/drive_c/" + this._name)
-        .extract();
+    url(url) {
+        this._url = url;
+        return this;
+    }
 
-    this._postInstall(wine, setupWizard);
+    checksum(checksum) {
+        this._checksum = checksum;
+        return this;
+    }
 
-    this._createShortcut(wine.prefix());
+    go() {
+        const setupWizard = SetupWizard(InstallationType.APPS, this._name, this.miniature());
 
-    // back to generic wait (might have been changed in postInstall)
-    setupWizard.wait(tr("Please wait..."));
+        setupWizard.presentation(this._name, this._editor, this._applicationHomepage, this._author);
 
-    setupWizard.close();
-};
+        const wine = new Wine()
+            .wizard(setupWizard)
+            .prefix(this._name, this._wineDistribution, this._wineArchitecture, this._wineVersion)
+            .create()
+            .luna()
+            .wait();
+
+        this._preInstall(wine, setupWizard);
+
+        // back to generic wait (might have been changed in preInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        let archive = "";
+        if (!this._url) {
+            archive = setupWizard.browse(tr("Please select the .zip file."), wine.prefixDirectory(), ["zip"]);
+        } else {
+            archive = wine.prefixDirectory() + "/drive_c/archive.zip";
+            new Downloader()
+                .wizard(setupWizard)
+                .url(this._url)
+                .checksum(this._checksum)
+                .to(archive)
+                .get();
+        }
+
+        new Extractor()
+            .wizard(setupWizard)
+            .archive(archive)
+            .to(wine.prefixDirectory() + "/drive_c/" + this._name)
+            .extract();
+
+        this._postInstall(wine, setupWizard);
+
+        this._createShortcut(wine.prefix());
+
+        // back to generic wait (might have been changed in postInstall)
+        setupWizard.wait(tr("Please wait..."));
+
+        setupWizard.close();
+    }
+}


### PR DESCRIPTION
This PR refactors the quick script classes with the newer and better understandable JavaScript class syntax. In addition this PR replaces the `var` keyword with the `const` or `let` keyword depending on whether the variable is a constant or not.

@plata @qparis @ImperatorS79 I've tested the changes in this PR by reinstalling Notepad++. Because this only uses three of the quick script classes it would be nice if you can test some of the others, which I'm unable to (origin, gog, local, custom, uplay, zip)