### PR TITLE
Fix an error with libncurses from runtime

### DIFF
--- a/Engines/Wine/Tools/Wine Terminal Opener/script.js
+++ b/Engines/Wine/Tools/Wine Terminal Opener/script.js
@@ -13,6 +13,7 @@ var toolImplementation = {
         environment["WINEPREFIX"] = wine.prefixDirectory();
         environment["PATH"] = wine.binPath() + ":$PATH";
         environment["LD_LIBRARY_PATH"] = Bean("propertyReader").getProperty("application.environment.ld");
+        environment["TERM"] = "xterm";
         var wineEnginesDirectory = Bean("propertyReader").getProperty("application.user.engines") + "/wine";
         var winePath = wine.binPath().substring(0, wine.binPath().length - 5); //trim /bin/
         if (wine.architecture() == "amd64") {


### PR DESCRIPTION
### Description
I will add libncurses 32 bits in the runtime also since I found why it did not work, but it needs this.

### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
