### PR TITLE
Update Mp3tag, updated link and checksum

### DIFF
--- a/Applications/Multimedia/Mp3tag/Online/script.js
+++ b/Applications/Multimedia/Mp3tag/Online/script.js
@@ -7,8 +7,8 @@ var installerImplementation = {
             .editor("Florian Heidenreich")
             .applicationHomepage("http://www.mp3tag.de/")
             .author("ImperatorS79")
-            .url("https://download.mp3tag.de/mp3tagv291setup.exe")
-            .checksum("b3fe9ee9b3b65cc1de2e3056f0f7ed675bb2fca0")
+            .url("https://download.mp3tag.de/mp3tagv295setup.exe")
+            .checksum("232e66127eae0adff24d31dd3141621e740cf405")
             .category("Multimedia")
             .executable("mp3tag.exe")
             .go();


### PR DESCRIPTION
### Description
Before the change the script wold give the "cheksum mismatch" error.
### What works
Everything
### What was not tested
Nothing
### Test
- Operating system (and linux kernel version): Ubuntu 19.04 x64 (5.0.0-17-generic)
- Hardware (GPU/CPU):
CPU: i7-7700L
GPU: Zotac GTX 1080 TI mini
### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
