### PR TITLE
Update FAudio (add new versions, remove x32 support)

### DIFF
--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -10,7 +10,7 @@ include("utils.functions.filesystem.files");
 * @returns {Wine} Wine object
 */
 Wine.prototype.faudio = function (faudioVersion) {
-    if (this.architecture() =! "amd64")
+    if (this.architecture() != "amd64")
         this.wizard().message(tr("FAudio does not support 32bit architecture."));
     if (typeof faudioVersion !== 'string')
         faudioVersion = "19.06.07";

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -30,24 +30,12 @@ Wine.prototype.faudio = function (faudioVersion) {
     var faudioDir = this.prefixDirectory() + "/FAudio/faudio-" + faudioVersion;
     var self = this;
 
-    forEach.call(ls(faudioDir + "/x32"), function (file) {
-        if (file.endsWith(".dll")) {
-            cp(faudioDir + "/x32/" + file, sys32dir);
-            self.overrideDLL()
-                .set("native", [file])
-                .do();
-        }
-    });
-
-    if (this.architecture() == "amd64")
-    {
-        var sys64dir = this.system64directory();
+    var sys64dir = this.system64directory();
         forEach.call(ls(faudioDir + "/x64"), function (file) {
             if (file.endsWith(".dll")) {
                 cp(faudioDir + "/x64/" + file, sys64dir);
-            }
-        });
-    }
+        }
+    });
 
     return this;
 }

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -11,9 +11,13 @@ include("utils.functions.filesystem.files");
 */
 Wine.prototype.faudio = function (faudioVersion) {
     if (this.architecture() != "amd64")
+    {
         throw "FAudio does not support 32bit architecture.";
+    }
     if (typeof faudioVersion !== 'string')
+    {
         faudioVersion = "19.06.07";
+    }
 
     var setupFile = new Resource()
         .wizard(this.wizard())

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -11,8 +11,7 @@ include("utils.functions.filesystem.files");
 */
 Wine.prototype.faudio = function (faudioVersion) {
     if (this.architecture() != "amd64")
-        this.wizard().message(tr("FAudio does not support 32bit architecture."));
-        break;
+        throw "FAudio does not support 32bit architecture.";
     if (typeof faudioVersion !== 'string')
         faudioVersion = "19.06.07";
 

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -35,6 +35,7 @@ Wine.prototype.faudio = function (faudioVersion) {
     forEach.call(ls(faudioDir + "/x64"), function (file) {
         if (file.endsWith(".dll")) {
             cp(faudioDir + "/x64/" + file, sys64dir);
+            self.overrideDLL()
         }
     });
 

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -10,6 +10,8 @@ include("utils.functions.filesystem.files");
 * @returns {Wine} Wine object
 */
 Wine.prototype.faudio = function (faudioVersion) {
+    if (this.architecture() =! "amd64")
+        this.wizard().message(tr("FAudio does not support 32bit architecture."));
     if (typeof faudioVersion !== 'string')
         faudioVersion = "19.06.07";
 

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -11,7 +11,7 @@ include("utils.functions.filesystem.files");
 */
 Wine.prototype.faudio = function (faudioVersion) {
     if (typeof faudioVersion !== 'string')
-        faudioVersion = "19.05";
+        faudioVersion = "19.06.07";
 
     var setupFile = new Resource()
         .wizard(this.wizard())
@@ -60,8 +60,8 @@ var verbImplementation = {
         var wine = new Wine();
         wine.prefix(container);
         var wizard = SetupWizard(InstallationType.VERBS, "FAudio", java.util.Optional.empty());
-        var versions = ["19.05", "19.04", "19.03", "19.02", "19.01"];
-        var selectedVersion = wizard.menu(tr("Please select the version."), versions, "19.05");
+        var versions = ["19.06.07", "19.06", "19.05", "19.04", "19.03", "19.02", "19.01"];
+        var selectedVersion = wizard.menu(tr("Please select the version."), versions, "19.06.07");
         wine.wizard(wizard);
         // install selected version
         wine.faudio(selectedVersion.text);

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -12,6 +12,7 @@ include("utils.functions.filesystem.files");
 Wine.prototype.faudio = function (faudioVersion) {
     if (this.architecture() != "amd64")
         this.wizard().message(tr("FAudio does not support 32bit architecture."));
+        break;
     if (typeof faudioVersion !== 'string')
         faudioVersion = "19.06.07";
 

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -26,14 +26,13 @@ Wine.prototype.faudio = function (faudioVersion) {
         .extract();
 
     var forEach = Array.prototype.forEach;
-    var sys32dir = this.system32directory();
+    var sys64dir = this.system64directory();
     var faudioDir = this.prefixDirectory() + "/FAudio/faudio-" + faudioVersion;
     var self = this;
 
-    var sys64dir = this.system64directory();
-        forEach.call(ls(faudioDir + "/x64"), function (file) {
-            if (file.endsWith(".dll")) {
-                cp(faudioDir + "/x64/" + file, sys64dir);
+    forEach.call(ls(faudioDir + "/x64"), function (file) {
+        if (file.endsWith(".dll")) {
+            cp(faudioDir + "/x64/" + file, sys64dir);
         }
     });
 

--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -36,6 +36,8 @@ Wine.prototype.faudio = function (faudioVersion) {
         if (file.endsWith(".dll")) {
             cp(faudioDir + "/x64/" + file, sys64dir);
             self.overrideDLL()
+                .set("native", [file])
+                .do();
         }
     });
 


### PR DESCRIPTION
### Description
Added version 19.06 and 19.06.07. When installing 19.06.07 this error shows up when the script is trying to extract the .sh file:
```
[INFO ] org.phoenicis.tools.archive.Tar (l.172) - Creating output file /home/jonasz/.Phoenicis/containers/wineprefix/Space Engineers/FAudio/faudio-19.06.07/wine_setup_faudio.sh (493).
[ERROR] org.phoenicis.multithreading.ControlledThreadPoolExecutorService (l.64) - org.graalvm.polyglot.PolyglotException
	at java.base/java.util.Arrays.stream(Arrays.java:5614)
	at org.phoenicis.tools.files.FileUtilities.ls(FileUtilities.java:49)
	at <js> ls(utils.functions.filesystem.files:12:393-438)
	at <js> Wine.faudio(engines.wine.verbs.faudio:34:1140-1161)
	at <js> install(engines.wine.verbs.faudio:68:2213-2245)
	at org.graalvm.sdk/org.graalvm.polyglot.Value.executeVoid(Value.java:360)
	at org.phoenicis.engines.Verb$$JSJavaAdapter.install(Unknown Source)
	at org.phoenicis.engines.VerbsManager.lambda$installVerb$0(VerbsManager.java:67)
	at org.phoenicis.scripts.session.PhoenicisInteractiveScriptSession.eval(PhoenicisInteractiveScriptSession.java:35)
	at org.phoenicis.scripts.interpreter.BackgroundScriptInterpreter.lambda$createInteractiveSession$1(BackgroundScriptInterpreter.java:45)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by host exception: java.lang.NullPointerException

Exception in thread "pool-3-thread-15" org.graalvm.polyglot.PolyglotException
	at java.base/java.util.Arrays.stream(Arrays.java:5614)
	at org.phoenicis.tools.files.FileUtilities.ls(FileUtilities.java:49)
	at <js> ls(utils.functions.filesystem.files:12:393-438)
	at <js> Wine.faudio(engines.wine.verbs.faudio:34:1140-1161)
	at <js> install(engines.wine.verbs.faudio:68:2213-2245)
	at org.graalvm.sdk/org.graalvm.polyglot.Value.executeVoid(Value.java:360)
	at org.phoenicis.engines.Verb$$JSJavaAdapter.install(Unknown Source)
	at org.phoenicis.engines.VerbsManager.lambda$installVerb$0(VerbsManager.java:67)
	at org.phoenicis.scripts.session.PhoenicisInteractiveScriptSession.eval(PhoenicisInteractiveScriptSession.java:35)
	at org.phoenicis.scripts.interpreter.BackgroundScriptInterpreter.lambda$createInteractiveSession$1(BackgroundScriptInterpreter.java:45)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by host exception: java.lang.NullPointerException
```
### What works
Installing every other version
### What was not tested

### Test
- Operating system (and linux kernel version): Ubuntu 19.04 x64 (5.0.0-17-generic )
- Hardware (GPU/CPU):
CPU: i7-7700K
GPU: GTX 1080 TI
### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
