### PR TITLE
Update runtime: fix an error when a directory does not exist

### DIFF
--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -169,8 +169,12 @@ var engineImplementation = {
         }
 
         if (download == true) {
-            remove(this._wineEnginesDirectory + "/runtime/lib");
-            remove(this._wineEnginesDirectory + "/runtime/lib64");
+            if(fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
+                remove(this._wineEnginesDirectory + "/runtime/lib");
+            }
+            if(fileExists(this._wineEnginesDirectory + "/runtime/lib64")) {
+                remove(this._wineEnginesDirectory + "/runtime/lib64");
+            }
             mkdir(this._wineEnginesDirectory + "/TMP");
             var that = this;
             runtimeJson.forEach(function (archive){

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -169,10 +169,10 @@ var engineImplementation = {
         }
 
         if (download == true) {
-            if(fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
+            if (fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
                 remove(this._wineEnginesDirectory + "/runtime/lib");
             }
-            if(fileExists(this._wineEnginesDirectory + "/runtime/lib64")) {
+            if (fileExists(this._wineEnginesDirectory + "/runtime/lib64")) {
                 remove(this._wineEnginesDirectory + "/runtime/lib64");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");


### PR DESCRIPTION
### Description
Only can be seen for a first installation. 
@qparis There is nor runtime x86 with name 201906221529, which will cause bugs since the runtime code expect amd64 and x86 runtime to have the same name (and it should be the same since they are always updated at the same time). I recommand you delete the runtime.json and all the stored runtime archives and properly upload latest amd64 and x86 runtime and a new runtime.json.

### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
