### PR TITLE
Refactor the "AppResource" class

### DIFF
--- a/Engines/Wine/QuickScript/Quick Script/script.js
+++ b/Engines/Wine/QuickScript/Quick Script/script.js
@@ -113,7 +113,7 @@ class QuickScript {
         this._preInstall = preInstall;
         return this;
     }
-    
+
     /**
      * set environment
      * @param {string} environment variables

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -33,7 +33,7 @@ class AppResource {
         const foundResource = Java.from(this._application.resources).find(resource => resource.name === resourceName);
 
         if (!foundResource) {
-            throw new Error(`Application "${this._application.name}" does not contain resource "resourceName"`);
+            throw new Error(`Application "${this._application.name}" does not contain resource "${resourceName}"`);
         }
 
         return foundResource.content;

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -1,36 +1,40 @@
 /**
-* AppResource prototype
-* @constructor
-*/
-function AppResource() {
-    this._appsManager = Bean("repositoryManager");
-}
-
-/**
-* sets application
-* @param {string} application application of the resource
-* @returns {AppResource} AppResource object
-*/
-AppResource.prototype.application = function (application) {
-    this._application = application;
-    return this;
-}
-
-/**
-* returns resource
-* @param {string} resourceName name of the resource
-* @returns {Resource} found resource
-*/
-AppResource.prototype.get = function (resourceName) {
-    var application = this._appsManager.getApplication(this._application);
-    var foundResource = null;
-    if (application != null && application.resources != null) {
-        application.resources.forEach(function (resource) {
-            if (resource.name == resourceName) {
-                foundResource = resource.content;
-            }
-        });
+ * AppResource class
+ */
+// eslint-disable-next-line no-unused-vars
+class AppResource {
+    constructor() {
+        this.appsManager = Bean("repositoryManager");
     }
 
-    return foundResource;
+    /**
+     * Sets the application containing the resources
+     *
+     * @param {string} application The application with the resource
+     * @returns {AppResource} The AppResource object
+     */
+    application(application) {
+        this._application = this.appsManager.getApplication(application);
+
+        return this;
+    }
+
+    /**
+     * Returns the searched resource
+     * @param {string} resourceName The name of the resource
+     * @returns {Resource} The found resource
+     */
+    get(resourceName) {
+        if (!this._application || !this._application.resources) {
+            throw new Error(`Unable to fetch resource from "null" application`);
+        }
+
+        const foundResource = Java.from(this._application.resources).find(resource => resource.name === resourceName);
+
+        if (!foundResource) {
+            throw new Error(`Application "${this._application.name}" does not contain resource "resourceName"`);
+        }
+
+        return foundResource.content;
+    }
 }

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -21,6 +21,7 @@ class AppResource {
 
     /**
      * Returns the searched resource
+     *
      * @param {string} resourceName The name of the resource
      * @returns {Resource} The found resource
      */

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -16,6 +16,10 @@ class AppResource {
     application(application) {
         this._application = this.appsManager.getApplication(application);
 
+        if (!this._application) {
+            print(`Warning: unable to fetch application "${application}"`);
+        }
+
         return this;
     }
 


### PR DESCRIPTION
This PR refactors the `AppResource` class. This contains:
- change the class to use the newer ES 6 `class` syntax
- fetch the `ApplicationDTO` object already in the `application(application)` method
- forbid `null` return values, throw errors instead. Normally a script **expects** a fetched file to exist