### PR TITLE
Fix x86 runtime not being downloaded

### DIFF
--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -107,8 +107,10 @@ class WineEngine {
         var runtimeJsonPath = this._wineEnginesDirectory + "/runtime.json";
         var runtimeJson;
         var runtimeJsonFile;
-        var download = false;
-        var name;
+        var downloadx86 = false;
+        var downloadx64 = false;
+        var namex86;
+        var namex64;
         if (!fileExists(runtimeJsonPath)) {
             mkdir(this._wineEnginesDirectory + "/runtime");
             runtimeJsonFile = new Downloader()
@@ -119,18 +121,26 @@ class WineEngine {
                 .get();
 
             runtimeJson = JSON.parse(cat(runtimeJsonFile));
-            download = true;
+            downloadx86 = true;
+            downloadx64 = true;
 
-            var maxVersion = 0;
+            var maxVersionx86 = 0;
+            var maxVersionx64 = 0;
             runtimeJson.forEach(function (archive) {
                 if (archive.arch == "amd64") {
-                    if (archive.name > maxVersion) {
-                        maxVersion = archive.name;
+                    if (archive.name > maxVersionx64) {
+                        maxVersionx64 = archive.name;
+                    }
+                }
+                else if (archive.arch == "x86") {
+                    if (archive.name > maxVersionx86) {
+                        maxVersionx86 = archive.name;
                     }
                 }
             });
 
-            name = maxVersion;
+            namex86 = maxVersionx86;
+            namex64 = maxVersionx64;
         }
         else {
             var oldRuntimeJsonFile = cat(this._wineEnginesDirectory + "/runtime.json");
@@ -145,37 +155,50 @@ class WineEngine {
 
             runtimeJson = JSON.parse(cat(runtimeJsonFile));
 
-            var maxVersion2 = 0;
+            var maxVersion2x86 = 0;
+            var maxVersion2x64 = 0;
 
             runtimeJson.forEach(function (archive) {
                 if (archive.arch == "amd64") {
-                    if (archive.name > maxVersion2) {
-                        maxVersion2 = archive.name;
+                    if (archive.name > maxVersion2x64) {
+                        maxVersion2x64 = archive.name;
+                    }
+                }
+                else if (archive.arch == "x86") {
+                    if (archive.name > maxVersion2x86) {
+                        maxVersion2x86 = archive.name;
                     }
                 }
             });
 
-            var oldMaxVersion = 0;
+            var oldMaxVersionx86 = 0;
+            var oldMaxVersionx64 = 0;
 
             oldRuntimeJson.forEach(function (archive) {
                 if (archive.arch == "amd64") {
-                    if (archive.name > oldMaxVersion) {
-                        oldMaxVersion = archive.name;
+                    if (archive.name > oldMaxVersionx64) {
+                        oldMaxVersionx64 = archive.name;
+                    }
+                }
+                else if (archive.arch == "x86") {
+                    if (archive.name > oldMaxVersionx86) {
+                        oldMaxVersionx86 = archive.name;
                     }
                 }
             });
 
-            if (maxVersion2 > oldMaxVersion) {
-                name = maxVersion2;
-                download = true;
+            if (maxVersion2x86 > oldMaxVersionx86) {
+                namex86 = maxVersion2x86;
+                downloadx86 = true;
+            }
+            if (maxVersion2x64 > oldMaxVersionx64) {
+                namex64 = maxVersion2x64;
+                downloadx64 = true;
             }
 
         }
 
-        if (download == true) {
-            if (fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
-                remove(this._wineEnginesDirectory + "/runtime/lib");
-            }
+        if (downloadx64 == true) {
             if (fileExists(this._wineEnginesDirectory + "/runtime/lib64")) {
                 remove(this._wineEnginesDirectory + "/runtime/lib64");
             }
@@ -183,12 +206,12 @@ class WineEngine {
             var that = this;
             runtimeJson.forEach(function (archive) {
                 var runtime;
-                if (archive.name == name) {
-                    if (archive.arch == "x86") {
+                if (archive.name == namex64) {
+                    if (archive.arch == "amd64") {
                         runtime = new Downloader()
                             .wizard(setupWizard)
                             .url(archive.url)
-                            .message(tr("Downloading x86 runtime..."))
+                            .message(tr("Downloading amd64 runtime..."))
                             .checksum(archive.sha1sum)
                             .to(that._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
                             .get();
@@ -199,11 +222,24 @@ class WineEngine {
                             .to(that._wineEnginesDirectory + "/runtime")
                             .extract();
                     }
-                    else {
+                }
+            });
+            remove(this._wineEnginesDirectory + "/TMP");
+        }
+        if (downloadx86 == true) {
+            if (fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
+                remove(this._wineEnginesDirectory + "/runtime/lib");
+            }
+            mkdir(this._wineEnginesDirectory + "/TMP");
+            var that = this;
+            runtimeJson.forEach(function (archive) {
+                var runtime;
+                if (archive.name == namex86) {
+                    if (archive.arch == "x86") {
                         runtime = new Downloader()
                             .wizard(setupWizard)
                             .url(archive.url)
-                            .message(tr("Downloading amd64 runtime..."))
+                            .message(tr("Downloading x86 runtime..."))
                             .checksum(archive.sha1sum)
                             .to(that._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
                             .get();

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -126,7 +126,7 @@ class WineEngine {
 
             var maxVersionx86 = 0;
             var maxVersionx64 = 0;
-            runtimeJson.forEach(function (archive) {
+            runtimeJson.forEach(archive => {
                 if (archive.arch == "amd64") {
                     if (archive.name > maxVersionx64) {
                         maxVersionx64 = archive.name;
@@ -158,7 +158,7 @@ class WineEngine {
             var maxVersion2x86 = 0;
             var maxVersion2x64 = 0;
 
-            runtimeJson.forEach(function (archive) {
+            runtimeJson.forEach(archive => {
                 if (archive.arch == "amd64") {
                     if (archive.name > maxVersion2x64) {
                         maxVersion2x64 = archive.name;
@@ -174,7 +174,7 @@ class WineEngine {
             var oldMaxVersionx86 = 0;
             var oldMaxVersionx64 = 0;
 
-            oldRuntimeJson.forEach(function (archive) {
+            oldRuntimeJson.forEach(archive => {
                 if (archive.arch == "amd64") {
                     if (archive.name > oldMaxVersionx64) {
                         oldMaxVersionx64 = archive.name;
@@ -203,8 +203,7 @@ class WineEngine {
                 remove(this._wineEnginesDirectory + "/runtime/lib64");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");
-            var that = this;
-            runtimeJson.forEach(function (archive) {
+            runtimeJson.forEach(archive => {
                 var runtime;
                 if (archive.name == namex64) {
                     if (archive.arch == "amd64") {
@@ -213,13 +212,13 @@ class WineEngine {
                             .url(archive.url)
                             .message(tr("Downloading amd64 runtime..."))
                             .checksum(archive.sha1sum)
-                            .to(that._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
+                            .to(this._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
                             .get();
 
                         new Extractor()
                             .wizard(setupWizard)
                             .archive(runtime)
-                            .to(that._wineEnginesDirectory + "/runtime")
+                            .to(this._wineEnginesDirectory + "/runtime")
                             .extract();
                     }
                 }
@@ -231,8 +230,7 @@ class WineEngine {
                 remove(this._wineEnginesDirectory + "/runtime/lib");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");
-            var that2 = this;
-            runtimeJson.forEach(function (archive) {
+            runtimeJson.forEach(archive => {
                 var runtime;
                 if (archive.name == namex86) {
                     if (archive.arch == "x86") {
@@ -241,13 +239,13 @@ class WineEngine {
                             .url(archive.url)
                             .message(tr("Downloading x86 runtime..."))
                             .checksum(archive.sha1sum)
-                            .to(that2._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
+                            .to(this._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
                             .get();
 
                         new Extractor()
                             .wizard(setupWizard)
                             .archive(runtime)
-                            .to(that2._wineEnginesDirectory + "/runtime")
+                            .to(this._wineEnginesDirectory + "/runtime")
                             .extract();
                     }
                 }

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -231,7 +231,7 @@ class WineEngine {
                 remove(this._wineEnginesDirectory + "/runtime/lib");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");
-            var that = this;
+            var that2 = this;
             runtimeJson.forEach(function (archive) {
                 var runtime;
                 if (archive.name == namex86) {
@@ -241,13 +241,13 @@ class WineEngine {
                             .url(archive.url)
                             .message(tr("Downloading x86 runtime..."))
                             .checksum(archive.sha1sum)
-                            .to(that._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
+                            .to(that2._wineEnginesDirectory + "/TMP/" + archive.url.substring(archive.url.lastIndexOf('/') + 1))
                             .get();
 
                         new Extractor()
                             .wizard(setupWizard)
                             .archive(runtime)
-                            .to(that._wineEnginesDirectory + "/runtime")
+                            .to(that2._wineEnginesDirectory + "/runtime")
                             .extract();
                     }
                 }

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -104,13 +104,13 @@ class WineEngine {
         }
     }
     _installRuntime(setupWizard) {
-        var runtimeJsonPath = this._wineEnginesDirectory + "/runtime.json";
-        var runtimeJson;
-        var runtimeJsonFile;
-        var downloadx86 = false;
-        var downloadx64 = false;
-        var namex86;
-        var namex64;
+        const runtimeJsonPath = this._wineEnginesDirectory + "/runtime.json";
+        let runtimeJson;
+        let runtimeJsonFile;
+        let downloadx86 = false;
+        let downloadx64 = false;
+        let namex86;
+        let namex64;
         if (!fileExists(runtimeJsonPath)) {
             mkdir(this._wineEnginesDirectory + "/runtime");
             runtimeJsonFile = new Downloader()
@@ -124,15 +124,15 @@ class WineEngine {
             downloadx86 = true;
             downloadx64 = true;
 
-            var maxVersionx86 = 0;
-            var maxVersionx64 = 0;
+            let maxVersionx86 = 0;
+            let maxVersionx64 = 0;
             runtimeJson.forEach(archive => {
-                if (archive.arch == "amd64") {
+                if (archive.arch === "amd64") {
                     if (archive.name > maxVersionx64) {
                         maxVersionx64 = archive.name;
                     }
                 }
-                else if (archive.arch == "x86") {
+                else if (archive.arch === "x86") {
                     if (archive.name > maxVersionx86) {
                         maxVersionx86 = archive.name;
                     }
@@ -143,8 +143,8 @@ class WineEngine {
             namex64 = maxVersionx64;
         }
         else {
-            var oldRuntimeJsonFile = cat(this._wineEnginesDirectory + "/runtime.json");
-            var oldRuntimeJson = JSON.parse(oldRuntimeJsonFile);
+            const oldRuntimeJsonFile = cat(this._wineEnginesDirectory + "/runtime.json");
+            const oldRuntimeJson = JSON.parse(oldRuntimeJsonFile);
 
             runtimeJsonFile = new Downloader()
                 .wizard(this._wizard)
@@ -155,32 +155,32 @@ class WineEngine {
 
             runtimeJson = JSON.parse(cat(runtimeJsonFile));
 
-            var maxVersion2x86 = 0;
-            var maxVersion2x64 = 0;
+            let maxVersion2x86 = 0;
+            let maxVersion2x64 = 0;
 
             runtimeJson.forEach(archive => {
-                if (archive.arch == "amd64") {
+                if (archive.arch === "amd64") {
                     if (archive.name > maxVersion2x64) {
                         maxVersion2x64 = archive.name;
                     }
                 }
-                else if (archive.arch == "x86") {
+                else if (archive.arch === "x86") {
                     if (archive.name > maxVersion2x86) {
                         maxVersion2x86 = archive.name;
                     }
                 }
             });
 
-            var oldMaxVersionx86 = 0;
-            var oldMaxVersionx64 = 0;
+            let oldMaxVersionx86 = 0;
+            let oldMaxVersionx64 = 0;
 
             oldRuntimeJson.forEach(archive => {
-                if (archive.arch == "amd64") {
+                if (archive.arch === "amd64") {
                     if (archive.name > oldMaxVersionx64) {
                         oldMaxVersionx64 = archive.name;
                     }
                 }
-                else if (archive.arch == "x86") {
+                else if (archive.arch === "x86") {
                     if (archive.name > oldMaxVersionx86) {
                         oldMaxVersionx86 = archive.name;
                     }
@@ -198,15 +198,15 @@ class WineEngine {
 
         }
 
-        if (downloadx64 == true) {
+        if (downloadx64 === true) {
             if (fileExists(this._wineEnginesDirectory + "/runtime/lib64")) {
                 remove(this._wineEnginesDirectory + "/runtime/lib64");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");
             runtimeJson.forEach(archive => {
-                var runtime;
-                if (archive.name == namex64) {
-                    if (archive.arch == "amd64") {
+                let runtime;
+                if (archive.name === namex64) {
+                    if (archive.arch === "amd64") {
                         runtime = new Downloader()
                             .wizard(setupWizard)
                             .url(archive.url)
@@ -225,15 +225,15 @@ class WineEngine {
             });
             remove(this._wineEnginesDirectory + "/TMP");
         }
-        if (downloadx86 == true) {
+        if (downloadx86 === true) {
             if (fileExists(this._wineEnginesDirectory + "/runtime/lib")) {
                 remove(this._wineEnginesDirectory + "/runtime/lib");
             }
             mkdir(this._wineEnginesDirectory + "/TMP");
             runtimeJson.forEach(archive => {
-                var runtime;
-                if (archive.name == namex86) {
-                    if (archive.arch == "x86") {
+                let runtime;
+                if (archive.name === namex86) {
+                    if (archive.arch === "x86") {
                         runtime = new Downloader()
                             .wizard(setupWizard)
                             .url(archive.url)


### PR DESCRIPTION
### Description
The bug came from the fact that x86 and amd64 runtime does not necessary have the same name
@Kreyren once this is loaded, could delete runtime and runtime.json in .Phoenicis/engines/wine, then retest steam game installation

### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
