### PR TITLE
Fix bad class naming for gallium 9 verb

### DIFF
--- a/Engines/Wine/Verbs/gallium9/script.js
+++ b/Engines/Wine/Verbs/gallium9/script.js
@@ -78,7 +78,7 @@ Wine.prototype.gallium9 = function (gallium9Version) {
  * Verb to install Gallium 9 Standalone
  */
 // eslint-disable-next-line no-unused-vars
-class FAudioVerb {
+class Gallium9Verb {
     constructor() {
         // do nothing
     }


### PR DESCRIPTION
### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
