### PR TITLE
Update Space Engineers (fix typo in message)

### DIFF
--- a/Applications/Games/Space Engineers/Steam/script.js
+++ b/Applications/Games/Space Engineers/Steam/script.js
@@ -22,6 +22,6 @@ new SteamScript()
             .set("native, builtin", ["msvcr120", "xaudio2_0", "xaudio2_1", "xaudio2_2", "xaudio2_3", "xaudio2_4", "xaudio2_5", "xaudio2_6", "xaudio2_7", "xaudio2_8", "xaudio2_9", "x3daudio1_3", "x3daudio1_4", "x3daudio1_5", "x3daudio1_6", "x3daudio1_7"])
             .do();
         wizard.message(tr("You have to install libjpeg62 and libjpeg62-dev or else the thumbnails in New Game menu will be dispalyed as magenta rectangles."));
-        wizard.message(tr("Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and peroid size to 2048."));
+        wizard.message(tr("Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and period size to 2048."));
     })
     .executable("Steam.exe", ["-silent", "-applaunch", 244850, "-no-ces-sandbox", "-skipintro"])

--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -383,7 +383,7 @@ Dragon\ Ball\ Xenoverse\ 2=Dragon Ball Xenoverse 2
 Druid\ Soccer=Druid Soccer
 
 #: Applications/Games/Space Engineers/Steam/script.js:25
-Due\ to\ JIT\ compiler\ issues\ and\ the\ way\ this\ game\ uses\ multithreating,\ there\ are\ audio\ stutters.\ This\ script\ will\ attempt\ to\ minimize\ them\ but\ you\ might\ also\ have\ to\ enter\ the\ alsoft-conf\ command\ in\ terminal\ and\ set\ sample\ depth\ to\ 32bit\ float\ and\ peroid\ size\ to\ 2048.=Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and peroid size to 2048.
+Due\ to\ JIT\ compiler\ issues\ and\ the\ way\ this\ game\ uses\ multithreating,\ there\ are\ audio\ stutters.\ This\ script\ will\ attempt\ to\ minimize\ them\ but\ you\ might\ also\ have\ to\ enter\ the\ alsoft-conf\ command\ in\ terminal\ and\ set\ sample\ depth\ to\ 32bit\ float\ and\ period\ size\ to\ 2048.=Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and period size to 2048.
 
 #: Applications/Games/Subnautica/Steam/script.js:30
 Due\ to\ a\ potential\ confilct\ with\ Vulkan,\ shader\ mods\ break\ the\ game\ (the\ executable\ file\ works\ but\ no\ window\ is\ displayed).=Due to a potential confilct with Vulkan, shader mods break the game (the executable file works but no window is displayed).

--- a/i18n/Messages.properties
+++ b/i18n/Messages.properties
@@ -383,7 +383,7 @@ Dragon\ Ball\ Xenoverse\ 2=Dragon Ball Xenoverse 2
 Druid\ Soccer=Druid Soccer
 
 #: Applications/Games/Space Engineers/Steam/script.js:25
-Due\ to\ JIT\ compiler\ issues\ and\ the\ way\ this\ game\ uses\ multithreating,\ there\ are\ audio\ stutters.\ This\ script\ will\ attempt\ to\ minimize\ them\ but\ you\ might\ also\ have\ to\ enter\ the\ alsoft-conf\ command\ in\ terminal\ and\ set\ sample\ depth\ to\ 32bit\ float\ and\ period\ size\ to\ 2048.=Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and period size to 2048.
+Due\ to\ JIT\ compiler\ issues\ and\ the\ way\ this\ game\ uses\ multithreating,\ there\ are\ audio\ stutters.\ This\ script\ will\ attempt\ to\ minimize\ them\ but\ you\ might\ also\ have\ to\ enter\ the\ alsoft-conf\ command\ in\ terminal\ and\ set\ sample\ depth\ to\ 32bit\ float\ and\ peroid\ size\ to\ 2048.=Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and peroid size to 2048.
 
 #: Applications/Games/Subnautica/Steam/script.js:30
 Due\ to\ a\ potential\ confilct\ with\ Vulkan,\ shader\ mods\ break\ the\ game\ (the\ executable\ file\ works\ but\ no\ window\ is\ displayed).=Due to a potential confilct with Vulkan, shader mods break the game (the executable file works but no window is displayed).


### PR DESCRIPTION
### Description
fixed typo on string 386: `peroid` > `period`
### What works
it work
### What was not tested
There is no test applied
### Test
- Operating system (and linux kernel version): 
MacOSX Mojave
- Hardware (GPU/CPU):
Macbook
### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [ ] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
