### PR TITLE
Improve Code Quality of the Utils Scripts

### DIFF
--- a/Utils/Functions/Apps/PlainInstaller/script.js
+++ b/Utils/Functions/Apps/PlainInstaller/script.js
@@ -1,7 +1,6 @@
 /**
  * A "plain" script installer that is fully configurable.
  */
-// eslint-disable-next-line no-unused-vars
 module.default = class PlainInstaller {
     constructor() {
         // do nothing
@@ -19,6 +18,10 @@ module.default = class PlainInstaller {
     }
 
     go() {
+        if (!this.command) {
+            throw new Error(`No command provided to "PlainInstaller"`);
+        }
+
         this.command();
     }
 }

--- a/Utils/Functions/Apps/Resources/script.js
+++ b/Utils/Functions/Apps/Resources/script.js
@@ -1,10 +1,11 @@
+const appsManager = Bean("repositoryManager");
+
 /**
  * AppResource class
  */
-// eslint-disable-next-line no-unused-vars
 module.default = class AppResource {
     constructor() {
-        this.appsManager = Bean("repositoryManager");
+        // nothing to do
     }
 
     /**
@@ -14,7 +15,7 @@ module.default = class AppResource {
      * @returns {AppResource} The AppResource object
      */
     application(application) {
-        this._application = this.appsManager.getApplication(application);
+        this._application = appsManager.getApplication(application);
 
         if (!this._application) {
             print(`Warning: unable to fetch application "${application}"`);

--- a/Utils/Functions/Filesystem/Extract/script.js
+++ b/Utils/Functions/Filesystem/Extract/script.js
@@ -1,12 +1,13 @@
 const {mkdir} = include("utils.functions.filesystem.files");
 
+const extractor = Bean("extractor");
+
 const ProcessBuilderClass = Java.type("java.lang.ProcessBuilder");
 const FileClass = Java.type("java.io.File");
 
 /**
  * CabExtract class
  */
-// eslint-disable-next-line no-unused-vars
 module.CabExtract = class CabExtract {
     constructor() {
         // do nothing
@@ -95,10 +96,9 @@ module.CabExtract = class CabExtract {
 /**
  * Extractor class
  */
-// eslint-disable-next-line no-unused-vars
 module.Extractor = class Extractor {
     constructor() {
-        this.extractor = Bean("extractor");
+        // nothing to do
     }
 
     /**
@@ -164,6 +164,6 @@ module.Extractor = class Extractor {
 
         mkdir(this._destination);
 
-        this.extractor.uncompress(this._archive, this._destination, progress => progressBar.accept(progress));
+        extractor.uncompress(this._archive, this._destination, progress => progressBar.accept(progress));
     }
 }

--- a/Utils/Functions/Filesystem/Files/script.js
+++ b/Utils/Functions/Filesystem/Files/script.js
@@ -1,4 +1,5 @@
-var fileUtilities = Bean("fileUtilities");
+const fileUtilities = Bean("fileUtilities");
+const checksumCalculator = Bean("checksumCalculator");
 
 /**
  * Lists all files and directories contained in the given path
@@ -6,10 +7,10 @@ var fileUtilities = Bean("fileUtilities");
  * @param {string} directoryPath directory path
  * @returns {string[]} list of files and directories
  */
-// eslint-disable-next-line no-unused-vars
 function ls(directoryPath) {
     return fileUtilities.ls(directoryPath);
 }
+module.ls = ls;
 
 /**
  * Creates the given directory
@@ -17,10 +18,10 @@ function ls(directoryPath) {
  * @param {string} directoryPath directory path
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function mkdir(directoryPath) {
     fileUtilities.mkdir(directoryPath);
 }
+module.mkdir = mkdir;
 
 /**
  * Checks if the given file exists
@@ -28,10 +29,10 @@ function mkdir(directoryPath) {
  * @param {string} filePath file path
  * @returns {boolean} true if file exists
  */
-// eslint-disable-next-line no-unused-vars
 function fileExists(filePath) {
     return fileUtilities.exists(filePath);
 }
+module.fileExists = fileExists;
 
 /**
  * Returns the file content of the given file
@@ -39,10 +40,10 @@ function fileExists(filePath) {
  * @param {string} filePath file path
  * @returns {string} content
  */
-// eslint-disable-next-line no-unused-vars
 function cat(filePath) {
     return fileUtilities.getFileContent(filePath);
 }
+module.cat = cat;
 
 /**
  * Copies the given source file to the target location
@@ -51,10 +52,10 @@ function cat(filePath) {
  * @param {string} target Target location
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function cp(source, target) {
     return fileUtilities.copy(source, target);
 }
+module.cp = cp;
 
 /**
  * Returns the file size of the given file
@@ -62,10 +63,10 @@ function cp(source, target) {
  * @param {string} filePath file path
  * @returns {number} file size
  */
-// eslint-disable-next-line no-unused-vars
 function getFileSize(filePath) {
     return fileUtilities.getSize(filePath);
 }
+module.getFileSize = getFileSize;
 
 /**
  * Returns the file name of the given file
@@ -73,10 +74,10 @@ function getFileSize(filePath) {
  * @param {string} filePath file path
  * @returns {string} file name
  */
-// eslint-disable-next-line no-unused-vars
 function fileName(filePath) {
     return fileUtilities.getFileName(filePath);
 }
+module.fileName = fileName;
 
 /**
  * Creates a symbolic link
@@ -85,10 +86,10 @@ function fileName(filePath) {
  * @param {string} link destination
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function lns(target, link) {
     return fileUtilities.createSymbolicLink(link, target);
 }
+module.lns = lns;
 
 /**
  * Removes the given file
@@ -96,10 +97,10 @@ function lns(target, link) {
  * @param {string} filePath file path
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function remove(filePath) {
     return fileUtilities.remove(filePath);
 }
+module.remove = remove;
 
 /**
  * Creates the given file if it does not exist
@@ -107,12 +108,12 @@ function remove(filePath) {
  * @param {string} filePath file path
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function touch(filePath) {
     if (!fileExists(filePath)) {
         fileUtilities.writeToFile(filePath, "");
     }
 }
+module.touch = touch;
 
 /**
  * Writes the given content to the given file
@@ -121,10 +122,10 @@ function touch(filePath) {
  * @param {string} content content which shall be written
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function writeToFile(filePath, content) {
     fileUtilities.writeToFile(filePath, content);
 }
+module.writeToFile = writeToFile;
 
 /**
  * Creates a new temporary file with the given file extension
@@ -132,20 +133,20 @@ function writeToFile(filePath, content) {
  * @param {string} extension file extension
  * @returns {string} file path of created temporary file
  */
-// eslint-disable-next-line no-unused-vars
 function createTempFile(extension) {
     return fileUtilities.createTmpFile(extension);
 }
+module.createTempFile = createTempFile;
 
 /**
  * Creates a new temporary temporary directory
  *
  * @returns {string} file path of created temporary directory
  */
-// eslint-disable-next-line no-unused-vars
 function createTempDir() {
     return fileUtilities.createTmpDir();
 }
+module.createTempDir = createTempDir;
 
 /**
  * Sets the given file permissions
@@ -154,18 +155,16 @@ function createTempDir() {
  * @param {string} permissions file permissions (e.g. "r--r--r--")
  * @returns {void}
  */
-// eslint-disable-next-line no-unused-vars
 function chmod(filePath, permissions) {
     fileUtilities.chmod(filePath, permissions);
 }
+module.chmod = chmod;
 
 /**
  * Checksum
  */
-// eslint-disable-next-line no-unused-vars
 module.Checksum = class Checksum {
     constructor() {
-        this.checksumCalculator = Bean("checksumCalculator");
         this._method = "SHA";
     }
 
@@ -211,29 +210,15 @@ module.Checksum = class Checksum {
      * @returns {string} The calculated checksum
      */
     get() {
+        let progressBar;
         if (this._wizard) {
-            var progressBar = this._wizard.progressBar(tr("Checking file consistency..."));
+            progressBar = this._wizard.progressBar(tr("Checking file consistency..."));
         }
 
-        return this.checksumCalculator.calculate(this._file, this._method, progressEntity => {
+        return checksumCalculator.calculate(this._file, this._method, progressEntity => {
             if (progressBar) {
                 progressBar.accept(progressEntity);
             }
         });
     }
 };
-
-module.ls = ls;
-module.mkdir = mkdir;
-module.fileExists = fileExists;
-module.cat = cat;
-module.cp = cp;
-module.getFileSize = getFileSize;
-module.fileName = fileName;
-module.lns = lns;
-module.remove = remove;
-module.touch = touch;
-module.writeToFile = writeToFile;
-module.createTempFile = createTempFile;
-module.createTempDir = createTempDir;
-module.chmod = chmod;

--- a/Utils/Functions/Net/Download/script.js
+++ b/Utils/Functions/Net/Download/script.js
@@ -1,12 +1,12 @@
 const {Checksum} = include("utils.functions.filesystem.files");
 
+const downloader = Bean("downloader");
+
 /**
  * Downloader class
  */
-// eslint-disable-next-line no-unused-vars
 module.default = class Downloader {
     constructor() {
-        this._downloader = Bean("downloader");
         this._algorithm = "SHA";
         this._headers = {};
     }
@@ -119,19 +119,20 @@ module.default = class Downloader {
             this._message = tr("Please wait while {0} is downloaded...", this._fetchFileNameFromUrl(this._url));
         }
 
+        let progressBar;
         if (this._wizard) {
-            var progressBar = this._wizard.progressBar(this._message);
+            progressBar = this._wizard.progressBar(this._message);
         }
 
         if (this._onlyIfUpdateAvailable) {
-            if (!this._downloader.isUpdateAvailable(this._localDestination, this._url)) {
+            if (!downloader.isUpdateAvailable(this._localDestination, this._url)) {
                 print(this._localDestination + " already up-to-date.");
                 return;
             }
         }
 
         if (this._localDestination) {
-            const downloadFile = this._downloader.get(
+            const downloadFile = downloader.get(
                 this._url,
                 this._localDestination,
                 this._headers,
@@ -150,7 +151,7 @@ module.default = class Downloader {
                     .get();
 
                 if (fileChecksum != this._checksum) {
-                    var checksumErrorMessage = tr(
+                    const checksumErrorMessage = tr(
                         'Error while calculating checksum for "{0}". \n\nExpected = {1}\nActual = {2}',
                         this._localDestination,
                         this._checksum,
@@ -165,7 +166,7 @@ module.default = class Downloader {
 
             return downloadFile.toString();
         } else {
-            return this._downloader.get(this._url, this._headers, function (progressEntity) {
+            return downloader.get(this._url, this._headers, progressEntity => {
                 if (progressBar) {
                     progressBar.accept(progressEntity);
                 }

--- a/Utils/Functions/Net/Resource/script.js
+++ b/Utils/Functions/Net/Resource/script.js
@@ -1,13 +1,14 @@
 const Downloader = include("utils.functions.net.download");
 const {mkdir, fileExists, Checksum} = include("utils.functions.filesystem.files");
 
+const propertyReader = Bean("propertyReader");
+
 /**
  * Resource class
  */
-// eslint-disable-next-line no-unused-vars
 module.default = class Resource {
     constructor() {
-        this._resourcesPath = Bean("propertyReader").getProperty("application.user.resources");
+        this._resourcesPath = propertyReader.getProperty("application.user.resources");
         this._algorithm = "SHA";
         this._directory = "";
     }

--- a/Utils/Functions/System/virtual desktop/script.js
+++ b/Utils/Functions/System/virtual desktop/script.js
@@ -2,19 +2,20 @@ const screenManager = Bean("screenManager");
 
 /**
  * Obtains the width of user's screen
+ *
  * @returns {number} width of user's screen in pixels
  */
 function getScreenWidth() {
     return screenManager.getScreenWidth();
 }
+module.getScreenWidth = getScreenWidth;
 
 /**
  * Obtains the height of user's screen
+ *
  * @returns {number} height of user's screen in pixels
  */
 function getScreenHeight() {
     return screenManager.getScreenHeight();
 }
-
-module.getScreenWidth = getScreenWidth;
 module.getScreenHeight = getScreenHeight;


### PR DESCRIPTION
This PR improves the code quality of the `Utils` scripts by:
- extracting the `Bean(...)` and `Java.type(...)` calls to the front of the utils scripts
- removing the now unnecessary `// eslint-disable-next-line no-unused-vars` comments

In addition this PR fixes some small issues