### PR TITLE
Update FAudio, added new versions

### DIFF
--- a/Engines/Wine/Verbs/FAudio/script.js
+++ b/Engines/Wine/Verbs/FAudio/script.js
@@ -17,7 +17,7 @@ Wine.prototype.faudio = function (faudioVersion) {
         throw "FAudio does not support 32bit architecture.";
     }
     if (typeof faudioVersion !== "string") {
-        faudioVersion = "19.06.07";
+        faudioVersion = "19.08";
     }
 
     var setupFile = new Resource()
@@ -66,9 +66,9 @@ module.default = class FAudioVerb {
 
     install(container) {
         const wizard = SetupWizard(InstallationType.VERBS, "FAudio", java.util.Optional.empty());
-        const versions = ["19.06.07", "19.06", "19.05", "19.04", "19.03", "19.02", "19.01"];
+        const versions = ["19.08", "19.07", "19.06.07", "19.06", "19.05", "19.04", "19.03", "19.02", "19.01"];
 
-        const selectedVersion = wizard.menu(tr("Please select the version."), versions, "19.06.07");
+        const selectedVersion = wizard.menu(tr("Please select the version."), versions, "19.08");
 
         const wine = new Wine();
         wine.prefix(container);


### PR DESCRIPTION
### Description

### What works
Seemingly everything (when `Space Engineers` use this version of the verb the audio tab in winecfg is corectly set to winepulse instead of ALSA which produces better audio) but I got this error when installing faudio 19.08 on a existing `Space Engineers` prefix:
```
[ERROR] net.sf.jmimemagic.MagicMatcher (l.731) - failed to load detector: 
                net.sf.jmimemagic.detectors.TextFileDetector
            
java.lang.ClassNotFoundException: 
                net.sf.jmimemagic.detectors.TextFileDetector
            
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:583)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:315)
	at net.sf.jmimemagic.MagicMatcher.getDetectorExtensions(MagicMatcher.java:726)
	at net.sf.jmimemagic.Magic.initialize(Magic.java:90)
	at net.sf.jmimemagic.Magic.getMagicMatch(Magic.java:175)
	at org.phoenicis.tools.files.FileAnalyser.getMatch(FileAnalyser.java:67)
	at org.phoenicis.tools.files.FileAnalyser.getMimetype(FileAnalyser.java:83)
	at org.phoenicis.tools.archive.Extractor.uncompress(Extractor.java:59)
	at org.phoenicis.tools.archive.Extractor.uncompress(Extractor.java:45)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostMethodDesc$SingleMethod$MHBase.invokeHandle(HostMethodDesc.java:269)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostMethodDesc$SingleMethod$MHBase.invoke(HostMethodDesc.java:261)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNode$1.executeImpl(HostExecuteNode.java:776)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.GuestToHostRootNode.execute(GuestToHostRootNode.java:87)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:328)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callInlinedForced(OptimizedCallTarget.java:279)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget$OptimizedCallInlined.call(OptimizedCallTarget.java:886)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.GuestToHostRootNode.guestToHostCall(GuestToHostRootNode.java:113)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNode.doInvoke(HostExecuteNode.java:786)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNode.doOverloadedCached(HostExecuteNode.java:215)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNodeGen.executeAndSpecialize(HostExecuteNodeGen.java:226)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNodeGen.executeImpl(HostExecuteNodeGen.java:94)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostExecuteNode.execute(HostExecuteNode.java:97)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostObject.invokeMember(HostObject.java:371)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostObjectGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(HostObjectGen.java:1308)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostObjectGen$InteropLibraryExports$Cached.invokeMember(HostObjectGen.java:1283)
	at org.graalvm.truffle/com.oracle.truffle.api.interop.InteropLibraryGen$CachedDispatch.invokeMember(InteropLibraryGen.java:3104)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$ForeignInvokeNode.executeCall(JSFunctionCallNode.java:1462)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:292)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:238)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:708)
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:212)
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:74)
	at com.oracle.truffle.js.nodes.control.BlockNode.execute(BlockNode.java:62)
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:73)
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:147)
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:93)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:328)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:318)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:305)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:287)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:242)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:63)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$UnboundJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1251)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:292)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:238)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:708)
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:212)
	at com.oracle.truffle.js.nodes.control.ExprBlockNode.execute(ExprBlockNode.java:68)
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:73)
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:147)
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:93)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:328)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:318)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:305)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:287)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:242)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:63)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$UnboundJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1251)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:292)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:238)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$InvokeNode.execute(JSFunctionCallNode.java:708)
	at com.oracle.truffle.js.nodes.JavaScriptNode.executeVoid(JavaScriptNode.java:212)
	at com.oracle.truffle.js.nodes.control.AbstractBlockNode.executeVoid(AbstractBlockNode.java:74)
	at com.oracle.truffle.js.nodes.control.BlockNode.execute(BlockNode.java:62)
	at com.oracle.truffle.js.nodes.function.FunctionBodyNode.execute(FunctionBodyNode.java:73)
	at com.oracle.truffle.js.nodes.function.FunctionRootNode.executeInRealm(FunctionRootNode.java:147)
	at com.oracle.truffle.js.runtime.JavaScriptRealmBoundaryRootNode.execute(JavaScriptRealmBoundaryRootNode.java:93)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:328)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:318)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:305)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:287)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callDirect(OptimizedCallTarget.java:242)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:63)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode$UnboundJSFunctionCacheNode.executeCall(JSFunctionCallNode.java:1251)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeAndSpecialize(JSFunctionCallNode.java:292)
	at com.oracle.truffle.js.nodes.function.JSFunctionCallNode.executeCall(JSFunctionCallNode.java:238)
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNode.doCached(JSInteropInvokeNode.java:88)
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNodeGen.executeAndSpecialize(JSInteropInvokeNodeGen.java:104)
	at com.oracle.truffle.js.nodes.interop.JSInteropInvokeNodeGen.execute(JSInteropInvokeNodeGen.java:62)
	at com.oracle.truffle.js.runtime.builtins.JSClass.invokeMember(JSClass.java:727)
	at com.oracle.truffle.js.runtime.builtins.JSClassGen$InteropLibraryExports$Cached.invokeMemberNode_AndSpecialize(JSClassGen.java:880)
	at com.oracle.truffle.js.runtime.builtins.JSClassGen$InteropLibraryExports$Cached.invokeMember(JSClassGen.java:856)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ProxyInvokeNode.invokeOrExecute(HostInteropReflect.java:608)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ProxyInvokeNode.doCachedMethod(HostInteropReflect.java:592)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ProxyInvokeNodeGen.executeAndSpecialize(ProxyInvokeNodeGen.java:117)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ProxyInvokeNodeGen.execute(ProxyInvokeNodeGen.java:65)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ObjectProxyNode.executeImpl(HostInteropReflect.java:535)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.HostToGuestRootNode.execute(HostToGuestRootNode.java:94)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callProxy(OptimizedCallTarget.java:328)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callRoot(OptimizedCallTarget.java:318)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callBoundary(OptimizedCallTarget.java:305)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.doInvoke(OptimizedCallTarget.java:287)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callIndirect(OptimizedCallTarget.java:230)
	at jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.call(OptimizedCallTarget.java:217)
	at org.graalvm.truffle/com.oracle.truffle.polyglot.ObjectProxyHandler.invoke(HostInteropReflect.java:678)
	at com.sun.proxy.$Proxy46.install(Unknown Source)
	at org.phoenicis.engines.VerbsManager.lambda$installVerb$0(VerbsManager.java:73)
	at org.phoenicis.scripts.session.PhoenicisInteractiveScriptSession.eval(PhoenicisInteractiveScriptSession.java:35)
	at org.phoenicis.scripts.interpreter.BackgroundScriptInterpreter.lambda$createInteractiveSession$1(BackgroundScriptInterpreter.java:45)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
### What was not tested
_to be filled in_
### Test
- Operating system (and linux kernel version): Ubuntu 19.04 x64 5.0.0-25-generic
- Hardware (GPU/CPU):
i7-7700k, gtx 1080 ti
### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
