### PR TITLE
Update Space Engineers, bumped up wine version and fixed few typos

### DIFF
--- a/Applications/Games/Space Engineers/Steam/script.js
+++ b/Applications/Games/Space Engineers/Steam/script.js
@@ -9,8 +9,8 @@ new SteamScript()
     .name("Space Engineers")
     .editor("Keen Software House")
     .author("Zemogiter")
-    .appId(244850)
-    .wineVersion("4.11")
+    .appId("244850")
+    .wineVersion("4.14")
     .wineDistribution("upstream")
     .wineArchitecture("amd64")
     .preInstall(function (wine, wizard) {
@@ -24,4 +24,4 @@ new SteamScript()
         wizard.message(tr("You have to install libjpeg62 and libjpeg62-dev or else the thumbnails in New Game menu will be dispalyed as magenta rectangles."));
         wizard.message(tr("Due to JIT compiler issues and the way this game uses multithreating, there are audio stutters. This script will attempt to minimize them but you might also have to enter the alsoft-conf command in terminal and set sample depth to 32bit float and period size to 2048."));
     })
-    .executable("Steam.exe", ["-silent", "-applaunch", 244850, "-no-ces-sandbox", "-skipintro"])
+    .executable("Steam.exe", ["-silent", "-applaunch", "244850", "-no-cef-sandbox", "-skipintro"])


### PR DESCRIPTION
### Description
It should be `no-cef-sandbox` not `no-ces-sandbox`
### What works
Everything but sometimes Wine decides to force ALSA instead of PulseAudio. This results in even choppier audio. But when I use winetricks to set it to pulse and go to the sound tab in winecfg I get "none" next to the "chosen driver".
### What was not tested
Nothing I can think of at this moment
### Test
- Operating system (and linux kernel version): Ubuntu 19.04 x64 5.0.0-25-generic
- Hardware (GPU/CPU):
i7-7700K, GTX 1080 ti
### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
