### PR TITLE
Add property to (not) use Wine runtime

### DIFF
--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -447,12 +447,17 @@ module.default = class WineEngine {
             ldPath = userData.ldPath + ldPath;
         }
 
+        let runtimePath = "";
+        let runtimePath64 = "";
+        if (this._useRuntime) {
+            runtimePath = this._wineEnginesDirectory + "/runtime/lib/";
+            runtimePath64 = this._wineEnginesDirectory + "/runtime/lib64/";
+        }
+
         if (architecture == "amd64") {
             ldPath =
-                this._wineEnginesDirectory +
-                (this._useRuntime ? "/runtime/lib64/:" : "") +
-                this._wineEnginesDirectory +
-                (this._useRuntime ? "/runtime/lib/:" : "") +
+                runtimePath64 + ":" +
+                runtimePath + ":" +
                 this.getLocalDirectory(subCategory, version) +
                 "/lib64/:" +
                 this.getLocalDirectory(subCategory, version) +
@@ -460,8 +465,7 @@ module.default = class WineEngine {
                 ldPath;
         } else {
             ldPath =
-                this._wineEnginesDirectory +
-                (this._useRuntime ? "/runtime/lib/:" : "") +
+                runtimePath + ":" +
                 this.getLocalDirectory(subCategory, version) +
                 "/lib/:" +
                 ldPath;

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -23,6 +23,7 @@ module.default = class WineEngine {
         this._ldPath = propertyReader.getProperty("application.environment.ld");
         this._wineEnginesDirectory = propertyReader.getProperty("application.user.engines") + "/wine";
         this._winePrefixesDirectory = propertyReader.getProperty("application.user.containers") + "/" + WINE_PREFIX_DIR + "/";
+        this._useRuntime = (propertyReader.getProperty("application.environment.wineRuntime") !== "false");
         this._wineWebServiceUrl = propertyReader.getProperty("webservice.wine.url");
         this._wizard = null;
         this._workingContainer = "";
@@ -43,7 +44,9 @@ module.default = class WineEngine {
     }
 
     install(subCategory, version) {
-        this._installRuntime(this.getWizard());
+        if (this._useRuntime) {
+            this._installRuntime(this.getWizard());
+        }
 
         const [distribution, , architecture] = subCategory.split("-");
         const localDirectory = this.getLocalDirectory(subCategory, version);
@@ -447,9 +450,9 @@ module.default = class WineEngine {
         if (architecture == "amd64") {
             ldPath =
                 this._wineEnginesDirectory +
-                "/runtime/lib64/:" +
+                (this._useRuntime ? "/runtime/lib64/:" : "") +
                 this._wineEnginesDirectory +
-                "/runtime/lib/:" +
+                (this._useRuntime ? "/runtime/lib/:" : "") +
                 this.getLocalDirectory(subCategory, version) +
                 "/lib64/:" +
                 this.getLocalDirectory(subCategory, version) +
@@ -458,7 +461,7 @@ module.default = class WineEngine {
         } else {
             ldPath =
                 this._wineEnginesDirectory +
-                "/runtime/lib/:" +
+                (this._useRuntime ? "/runtime/lib/:" : "") +
                 this.getLocalDirectory(subCategory, version) +
                 "/lib/:" +
                 ldPath;

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -453,21 +453,20 @@ module.default = class WineEngine {
             runtimePath = this._wineEnginesDirectory + "/runtime/lib/";
             runtimePath64 = this._wineEnginesDirectory + "/runtime/lib64/";
         }
+        const wineLibPath = this.getLocalDirectory(subCategory, version) + "/lib/";
+        const wineLibPath64 = this.getLocalDirectory(subCategory, version) + "/lib64/";
 
         if (architecture == "amd64") {
             ldPath =
                 runtimePath64 + ":" +
                 runtimePath + ":" +
-                this.getLocalDirectory(subCategory, version) +
-                "/lib64/:" +
-                this.getLocalDirectory(subCategory, version) +
-                "/lib/:" +
+                wineLibPath64 + ":" +
+                wineLibPath + ":" +
                 ldPath;
         } else {
             ldPath =
                 runtimePath + ":" +
-                this.getLocalDirectory(subCategory, version) +
-                "/lib/:" +
+                wineLibPath + ":" +
                 ldPath;
         }
         environment.put("LD_LIBRARY_PATH", ldPath);


### PR DESCRIPTION
set `application.environment.wineRuntime`, by default the runtime is used

fixes https://github.com/PhoenicisOrg/phoenicis/issues/1940