### PR TITLE
Update SteamScript (remove winxp overrides)

### DIFF
--- a/Applications/Games/Steam/Online/script.js
+++ b/Applications/Games/Steam/Online/script.js
@@ -2,7 +2,6 @@ const OnlineInstallerScript = include("engines.wine.quick_script.online_installe
 const { LATEST_STAGING_VERSION } = include("engines.wine.engine.versions");
 
 const Corefonts = include("engines.wine.verbs.corefonts");
-const WindowsVersion = include("engines.wine.plugins.windows_version");
 
 new OnlineInstallerScript()
     .name("Steam")
@@ -15,11 +14,6 @@ new OnlineInstallerScript()
     .wineVersion(LATEST_STAGING_VERSION)
     .wineDistribution("staging")
     .preInstall(function (wine) {
-        new WindowsVersion(wine)
-            .withApplicationWindowsVersion("steam.exe", "winxp")
-            .withApplicationWindowsVersion("steamwebhelper.exe", "winxp")
-            .go();
-
         new Corefonts(wine).go();
     })
     .executable("Steam.exe", ["-no-cef-sandbox"]);

--- a/Engines/Wine/QuickScript/Steam Script/script.js
+++ b/Engines/Wine/QuickScript/Steam Script/script.js
@@ -142,12 +142,6 @@ module.default = class SteamScript extends QuickScript {
         );
         wine.run(tempFile, [], null, false, true);
 
-        // Set windows environment for executable that needs it
-        new WindowsVersion(wine)
-            .withApplicationWindowsVersion("steam.exe", "winxp")
-            .withApplicationWindowsVersion("steamwebhelper.exe", "winxp")
-            .go();
-
         // Fix for Uplay games that are executed on steam
         new WindowsVersion(wine)
             .withApplicationWindowsVersion("upc.exe", "winvista")


### PR DESCRIPTION
### Description
After Steam overhauled their Library tab, support for windows xp was dropped entirely. This results in Steam client unable to start which breaks the sequence of events neceseary to get this script to work. Still need to figure out a new way to make both steam browser and library tab work. Currently both elements either dosen't work at all (black page) or work partially (page goes to black when scrolling, page displayed with black rectangles on some content, makes the `<div>` elements visible). A partial fix to #1138 
### What works
Installing games.
### What was not tested
Nothing
### Test
- Operating system (and linux kernel version): Ubuntu 19.10 5.3.0-19-generic
- Hardware (GPU/CPU): i7-7700K, GTX 1080 ti

### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
