### PR TITLE
Add missing architecture parameter to getLatestStableVersion() calls

### DIFF
--- a/Applications/Internet/Internet Explorer 6.0/Online/script.js
+++ b/Applications/Internet/Internet Explorer 6.0/Online/script.js
@@ -31,7 +31,7 @@ new PlainInstaller().withScript(() => {
 
     var wine = new Wine()
         .wizard(setupWizard)
-        .prefix("InternetExplorer6", "upstream", "x86", getLatestStableVersion(setupWizard))
+        .prefix("InternetExplorer6", "upstream", "x86", getLatestStableVersion(setupWizard, "x86"))
         .create();
 
     new Msls31(wine).go();

--- a/Applications/Internet/Internet Explorer 7.0/Online/script.js
+++ b/Applications/Internet/Internet Explorer 7.0/Online/script.js
@@ -21,7 +21,7 @@ new PlainInstaller().withScript(() => {
 
     var wine = new Wine()
         .wizard(setupWizard)
-        .prefix("InternetExplorer7", "upstream", "x86", getLatestStableVersion(setupWizard))
+        .prefix("InternetExplorer7", "upstream", "x86", getLatestStableVersion(setupWizard, "x86"))
         .create();
 
     new Sandbox(wine).go();

--- a/docs/_docs/Develop/script-js.md
+++ b/docs/_docs/Develop/script-js.md
@@ -287,7 +287,7 @@ setupWizard.presentation(application, "Editor", "http://applicationhomepage.com"
 
 const wine = new Wine()
     .wizard(setupWizard)
-    .prefix(application, "upstream", "x86", getLatestStableVersion(setupWizard));
+    .prefix(application, "upstream", "x86", getLatestStableVersion(setupWizard, "x86"));
 
 new Luna(wine).go();    
     


### PR DESCRIPTION
I forgot it in https://github.com/PhoenicisOrg/scripts/pull/1153/commits/320fd390821116d3e145945958201a013e836058.