### PR TITLE
Update Installer Script (run postInstall before shortcut creation)

### DIFF
--- a/Engines/Wine/QuickScript/Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Installer Script/script.js
@@ -95,9 +95,9 @@ module.default = class InstallerScript extends QuickScript {
             );
         }
 
-        this._createShortcut(wine.prefix());
-
         this._postInstall(wine, setupWizard);
+
+        this._createShortcut(wine.prefix());
 
         // back to generic wait (might have been changed in postInstall)
         setupWizard.wait(tr("Please wait..."));


### PR DESCRIPTION
### Description
Thanks to #1144 we have discovered that scripts will fail if `.executable()` points to a file that only exist after `postInstall` step is done. Since @plata mentioned something about Installer Script working this way for a reason (though I was unable to find that reason in closed PRs and issues) this is a WIP draft untill me or someone else test this with other scripts that use `postInstall`.
### What works
`Heroes of Might & Magic IV` no longer crash due to non-existing `.executable()`
### What was not tested
Other scripts with `postInstall`
### Test
- Operating system (and linux kernel version): Ubuntu 19.10
- Hardware (GPU/CPU): GTX 1080 ti, i7-7700K

### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
