### PR TITLE
Update Subnautica, using latest dev Wine version, disabling nvapi workaround, introduce environment values

### DIFF
--- a/Applications/Games/Subnautica/Steam/script.js
+++ b/Applications/Games/Subnautica/Steam/script.js
@@ -1,6 +1,7 @@
 const SteamScript = include("engines.wine.quick_script.steam_script");
-const { getLatestStableVersion } = include("engines.wine.engine.versions");
-
+const { getLatestDevelopmentVersion } = include("engines.wine.engine.versions");
+const OverrideDLL = include("engines.wine.plugins.override_dll");
+const { touch, writeToFile } = include("utils.functions.filesystem.files");
 const VirtualDesktop = include("engines.wine.plugins.virtual_desktop");
 const Vcrun2013 = include("engines.wine.verbs.vcrun2013");
 const Corefonts = include("engines.wine.verbs.corefonts");
@@ -12,29 +13,29 @@ new SteamScript()
     .author("Zemogiter")
     .applicationHomepage("https://unknownworlds.com/subnautica/")
     .wineDistribution("upstream")
-    .wineVersion(getLatestStableVersion)
+    .wineVersion(getLatestDevelopmentVersion)
     .wineArchitecture("amd64")
     .appId(264710)
     .preInstall((wine) => {
-        const wizard = wine.wizard();
-
-        wizard.message(
-            tr("You can make the game smoother by using this: https://github.com/lutris/lutris/wiki/How-to:-Esync")
-        );
-
         new Vcrun2013(wine).go();
         new Corefonts(wine).go();
         new DXVK(wine).go();
-
+        new OverrideDLL(wine)
+            .withMode("disabled", ["nvapi", "nvapi64"])
+            .go();
         new VirtualDesktop(wine).go();
+        const dxvkConfigFile = wine.prefixDirectory() + "/drive_c/dxvk.conf";
+        touch(dxvkConfigFile);
+        writeToFile(dxvkConfigFile, "dxgi.nvapiHack = False");
     })
     .postInstall((wine) => {
         const wizard = wine.wizard();
 
         wizard.message(
             tr(
-                "Due to a potential conflict with Vulkan, shader mods break the game (the executable file works but no window is displayed)."
+                "Due to a potential conflict with Vulkan, shader mods may break the game (the executable file works but no window is displayed)."
             )
         );
     })
-    .gameOverlay(false);
+    .gameOverlay(false)
+    .environment('{"DXVK_CONFIG_FILE": "configFile", "STAGING_SHARED_MEMORY": "0", "WINEESYNC": "1"}')


### PR DESCRIPTION
### Description
Tried playing this game today. It crashed with standard "Subnautica.exe stoped working" error. before displaying anything. Tried disabling any mods and QModManager. Still crashes. Reinstalling verbs via winetricks. Still crashes. Changing wine version from 4.0.3 to 5.0-rc3 finally did the trick.
### What works
Game installation and start
### What was not tested
Gameplay
### Test
- Operating system (and linux kernel version): Ubuntu 19.10
- Hardware (GPU/CPU): GTX 1080 ti, i7-7700K

### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [ ] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [ ] Codacy and travis checked.
