### PR TITLE
Update Implementation, changed how old runtimes are defined and improved the check for runtime.json

### DIFF
--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -51,7 +51,8 @@ module.default = class WineEngine {
         const [distribution, , architecture] = subCategory.split("-");
         const localDirectory = this.getLocalDirectory(subCategory, version);
 
-        // if not installed
+        // if not installed129:13  error  Parsing error: Assigning to rvalue
+
         if (!this.isInstalled(subCategory, version)) {
             let ownWizard = false;
             let wizard = this.getWizard();
@@ -66,7 +67,8 @@ module.default = class WineEngine {
 
             const wineJson = JSON.parse(this.getAvailableVersions());
 
-            wineJson
+            wineJson129:13  error  Parsing error: Assigning to rvalue
+
                 .filter(distribution => distribution.name === subCategory)
                 .flatMap(distribution => distribution.packages)
                 .forEach(winePackage => {
@@ -126,7 +128,7 @@ module.default = class WineEngine {
         let namex86;
         let namex64;
         print ("runtimeJsonPath: " + runtimeJsonPath);
-        if (!fileExists(runtimeJsonPath) || getFileSize(runtimeJsonPath) = 0) {
+        if (!fileExists(runtimeJsonPath) || getFileSize(runtimeJsonPath) == 0) {
             mkdir(this._wineEnginesDirectory + "/runtime");
 
             runtimeJsonFile = new Downloader()

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -125,6 +125,7 @@ module.default = class WineEngine {
         let downloadx64 = false;
         let namex86;
         let namex64;
+        print ("runtimeJsonPath: " + runtimeJsonPath);
         if (!fileExists(runtimeJsonPath)) {
             mkdir(this._wineEnginesDirectory + "/runtime");
 
@@ -156,8 +157,10 @@ module.default = class WineEngine {
             namex86 = maxVersionx86;
             namex64 = maxVersionx64;
         } else {
-            const oldRuntimeJsonFile = cat(this._wineEnginesDirectory + "/runtime.json");
+            const oldRuntimeJsonFile = cat(runtimeJsonPath);
+            print ("oldRuntimeJsonFile: " + oldRuntimeJsonFile);
             const oldRuntimeJson = JSON.parse(oldRuntimeJsonFile);
+            print ("oldRuntimeJson: " + oldRuntimeJson);
 
             runtimeJsonFile = new Downloader()
                 .wizard(setupWizard)
@@ -165,8 +168,10 @@ module.default = class WineEngine {
                 .url("https://phoenicis.playonlinux.com/index.php/runtime?os=linux")
                 .to(runtimeJsonPath)
                 .get();
+            print ("runtimeJsonFile: " + runtimeJsonFile);
 
             runtimeJson = JSON.parse(cat(runtimeJsonFile));
+            print ("runtimeJson: " + runtimeJson);
 
             let maxVersion2x86 = 0;
             let maxVersion2x64 = 0;

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -51,7 +51,7 @@ module.default = class WineEngine {
         const [distribution, , architecture] = subCategory.split("-");
         const localDirectory = this.getLocalDirectory(subCategory, version);
 
-        // if not installed129:13  error  Parsing error: Assigning to rvalue
+        // if not installed
 
         if (!this.isInstalled(subCategory, version)) {
             let ownWizard = false;

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -52,7 +52,6 @@ module.default = class WineEngine {
         const localDirectory = this.getLocalDirectory(subCategory, version);
 
         // if not installed
-
         if (!this.isInstalled(subCategory, version)) {
             let ownWizard = false;
             let wizard = this.getWizard();
@@ -68,7 +67,6 @@ module.default = class WineEngine {
             const wineJson = JSON.parse(this.getAvailableVersions());
 
             wineJson
-
                 .filter(distribution => distribution.name === subCategory)
                 .flatMap(distribution => distribution.packages)
                 .forEach(winePackage => {
@@ -127,7 +125,6 @@ module.default = class WineEngine {
         let downloadx64 = false;
         let namex86;
         let namex64;
-        print ("runtimeJsonPath: " + runtimeJsonPath);
         if (!fileExists(runtimeJsonPath) || getFileSize(runtimeJsonPath) == 0) {
             mkdir(this._wineEnginesDirectory + "/runtime");
 
@@ -168,10 +165,8 @@ module.default = class WineEngine {
                 .url("https://phoenicis.playonlinux.com/index.php/runtime?os=linux")
                 .to(runtimeJsonPath)
                 .get();
-            print ("runtimeJsonFile: " + runtimeJsonFile);
 
             runtimeJson = JSON.parse(cat(runtimeJsonFile));
-            print ("runtimeJson: " + runtimeJson);
 
             let maxVersion2x86 = 0;
             let maxVersion2x64 = 0;

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -159,8 +159,8 @@ module.default = class WineEngine {
             namex86 = maxVersionx86;
             namex64 = maxVersionx64;
         } else {
-            print ("oldRuntimeJsonFile: " + oldRuntimeJsonFile);
-            print ("oldRuntimeJson: " + oldRuntimeJson);
+            const oldRuntimeJsonFile = cat(this._wineEnginesDirectory + "/runtime.json");
+            const oldRuntimeJson = JSON.parse(oldRuntimeJsonFile);
 
             runtimeJsonFile = new Downloader()
                 .wizard(setupWizard)

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -1,4 +1,4 @@
-const { ls, mkdir, fileExists, cat, lns, remove, touch, createTempFile } = include("utils.functions.filesystem.files");
+const { ls, mkdir, fileExists, cat, lns, remove, touch, createTempFile, getFileSize } = include("utils.functions.filesystem.files");
 const { Extractor } = include("utils.functions.filesystem.extract");
 const Downloader = include("utils.functions.net.download");
 const Resource = include("utils.functions.net.resource");
@@ -126,7 +126,7 @@ module.default = class WineEngine {
         let namex86;
         let namex64;
         print ("runtimeJsonPath: " + runtimeJsonPath);
-        if (!fileExists(runtimeJsonPath)) {
+        if (!fileExists(runtimeJsonPath) || getFileSize(runtimeJsonPath) = 0) {
             mkdir(this._wineEnginesDirectory + "/runtime");
 
             runtimeJsonFile = new Downloader()
@@ -157,9 +157,7 @@ module.default = class WineEngine {
             namex86 = maxVersionx86;
             namex64 = maxVersionx64;
         } else {
-            const oldRuntimeJsonFile = cat(runtimeJsonPath);
             print ("oldRuntimeJsonFile: " + oldRuntimeJsonFile);
-            const oldRuntimeJson = JSON.parse(oldRuntimeJsonFile);
             print ("oldRuntimeJson: " + oldRuntimeJson);
 
             runtimeJsonFile = new Downloader()

--- a/Engines/Wine/Engine/Implementation/script.js
+++ b/Engines/Wine/Engine/Implementation/script.js
@@ -67,7 +67,7 @@ module.default = class WineEngine {
 
             const wineJson = JSON.parse(this.getAvailableVersions());
 
-            wineJson129:13  error  Parsing error: Assigning to rvalue
+            wineJson
 
                 .filter(distribution => distribution.name === subCategory)
                 .flatMap(distribution => distribution.packages)


### PR DESCRIPTION
### Description
fix https://github.com/PhoenicisOrg/phoenicis/issues/2172
### What works
Shortcuts and running exe files 
### What was not tested
How the script will behave if file in `runtimeJsonPath` is empty.
### Test
- Operating system (and linux kernel version): Ubuntu 19.04 x64 5.3.0-29-generic
- Hardware (GPU/CPU): GTX 1080 ti, i7-7700K

### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [ ] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
