### PR TITLE
Update SteamScript, changed .exe filename to lowercase

### DIFF
--- a/Applications/Games/Steam/Online/script.js
+++ b/Applications/Games/Steam/Online/script.js
@@ -16,4 +16,4 @@ new OnlineInstallerScript()
     .preInstall((wine) => {
         new Corefonts(wine).go();
     })
-    .executable("Steam.exe", ["-no-cef-sandbox"]);
+    .executable("steam.exe", ["-no-cef-sandbox"]);

--- a/Engines/Wine/QuickScript/Steam Script/script.js
+++ b/Engines/Wine/QuickScript/Steam Script/script.js
@@ -14,7 +14,7 @@ module.default = class SteamScript extends QuickScript {
     constructor() {
         super();
 
-        this._executable = "Steam.exe";
+        this._executable = "steam.exe";
         this._category = "Games";
         this._gameOverlay = true;
     }
@@ -151,7 +151,7 @@ module.default = class SteamScript extends QuickScript {
             .go();
 
         // ensure that Steam is running (user might have unchecked "run Steam after installation finished")
-        wine.runInsidePrefix(`${wine.programFiles()}/Steam/Steam.exe`, ["steam://nav/games"], false);
+        wine.runInsidePrefix(`${wine.programFiles()}/Steam/steam.exe`, ["steam://nav/games"], false);
 
         // wait until config.vdf exists
         while (!fileExists(this.configVdf(wine))) {
@@ -171,7 +171,7 @@ module.default = class SteamScript extends QuickScript {
         // back to generic wait (might have been changed in preInstall)
         setupWizard.wait(tr("Please wait..."));
 
-        wine.runInsidePrefix(`${wine.programFiles()}/Steam/Steam.exe`, [`steam://install/${this._appId}`], false);
+        wine.runInsidePrefix(`${wine.programFiles()}/Steam/steam.exe`, [`steam://install/${this._appId}`], false);
 
         setupWizard.wait(tr("Please wait until Steam has finished the download..."));
 
@@ -186,7 +186,7 @@ module.default = class SteamScript extends QuickScript {
         }
 
         // close Steam
-        wine.runInsidePrefix(`${wine.programFiles()}/Steam/Steam.exe`, "-shutdown", true);
+        wine.runInsidePrefix(`${wine.programFiles()}/Steam/steam.exe`, "-shutdown", true);
 
         // back to generic wait
         setupWizard.wait(tr("Please wait..."));


### PR DESCRIPTION
### Description
Steam installer now outputs `steam.exe` instead of `Steam.exe` which leads to errors
### What works
Installing Steam game
### What was not tested
Nothing
### Test
- Operating system (and linux kernel version): Ubuntu 20.04 x64 5.4.0-37-generic 
- Hardware (GPU/CPU): i7-7700K, GTX 1080 ti

### Ready for review
- [x] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [x] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [x] Codacy and travis checked.
