### PR TITLE
Update W2KSP4_EN.EXE URL to web.archive.org

### DIFF
--- a/Engines/Wine/Verbs/mspatcha/script.js
+++ b/Engines/Wine/Verbs/mspatcha/script.js
@@ -23,7 +23,7 @@ class Mspatcha {
         const setupFile = new Resource()
             .wizard(wizard)
             .url(
-                "https://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/win2000/Service_Packs/usa/W2KSP4_EN.EXE"
+                "https://web.archive.org/web/20160129053851if_/http://download.microsoft.com/download/E/6/A/E6A04295-D2A8-40D0-A0C5-241BFECD095E/W2KSP4_EN.EXE"
             )
             .checksum("fadea6d94a014b039839fecc6e6a11c20afa4fa8")
             .name("W2ksp4_EN.exe")


### PR DESCRIPTION
### Description
Simply replace a dead download link with a working one from archive.org

### What works
The Adobe Acrobat Reader DC installer is now working instead of hanging at the download step.

### What was not tested
Everything else

### Test
- Operating system (and linux kernel version): Fedora 32
- Hardware (GPU/CPU): - 

### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [ ] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [ ] Codacy and travis checked.
