### PR TITLE
Update Subnautica, using the updated link for Esync guide

### DIFF
--- a/Applications/Games/Subnautica/Steam/script.js
+++ b/Applications/Games/Subnautica/Steam/script.js
@@ -19,7 +19,7 @@ new SteamScript()
         const wizard = wine.wizard();
 
         wizard.message(
-            tr("You can make the game smoother by using this: https://github.com/lutris/lutris/wiki/How-to:-Esync")
+            tr("You can make the game smoother by using this: https://github.com/lutris/docs/blob/master/HowToEsync.md")
         );
 
         new Vcrun2013(wine).go();


### PR DESCRIPTION
The content of that link was moved to a different one.
