### PR TITLE
Update OnlineInstallerScript  Default check wine settings

### DIFF
--- a/Engines/Wine/QuickScript/Online Installer Script/script.js
+++ b/Engines/Wine/QuickScript/Online Installer Script/script.js
@@ -5,7 +5,7 @@ const { createTempFile } = include("utils.functions.filesystem.files");
 module.default = class OnlineInstallerScript extends InstallerScript {
     constructor() {
         super();
-
+        this._wineUserSettings = true;
         this._installationArgs = [];
     }
 


### PR DESCRIPTION
### Description

Currently OnlineInstallerScript does not work correctly since it defaults to upstream and no version.
Asking for wine settings configures correctly

### What works

### What was not tested

### Test
- Operating system (and linux kernel version): 
- Hardware (GPU/CPU):

### Ready for review
- [ ] Script tested as a regular phoenicis user and working (if you have a problem -> create as draft and ask for help).
- [ ] `json-align` and `eslint` run according to the [documentation](https://phoenicisorg.github.io/scripts/General/tools/). 
- [ ] Codacy and travis checked.
