### PR TITLE
corefonts: fix download URLs

### DIFF
--- a/Engines/Wine/Verbs/corefonts/script.js
+++ b/Engines/Wine/Verbs/corefonts/script.js
@@ -21,70 +21,70 @@ class Corefonts {
         const fontResources = [
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/arial32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/arial32.exe")
                 .checksum("6d75f8436f39ab2da5c31ce651b7443b4ad2916e")
                 .name("arial32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/arialb32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/arialb32.exe")
                 .checksum("d45cdab84b7f4c1efd6d1b369f50ed0390e3d344")
                 .name("arialb32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/comic32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/comic32.exe")
                 .checksum("2371d0327683dcc5ec1684fe7c275a8de1ef9a51")
                 .name("comic32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/courie32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/courie32.exe")
                 .checksum("06a745023c034f88b4135f5e294fece1a3c1b057")
                 .name("courie32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/georgi32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/georgi32.exe")
                 .checksum("90e4070cb356f1d811acb943080bf97e419a8f1e")
                 .name("georgi32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/impact32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/impact32.exe")
                 .checksum("86b34d650cfbbe5d3512d49d2545f7509a55aad2")
                 .name("impact32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/times32.exe")
+                .url("https://github.com/pushcx/corefonts/raw/master/times32.exe")
                 .checksum("20b79e65cdef4e2d7195f84da202499e3aa83060")
                 .name("times32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/trebuc32.exe ")
+                .url("https://github.com/pushcx/corefonts/raw/master/trebuc32.exe ")
                 .checksum("50aab0988423efcc9cf21fac7d64d534d6d0a34a")
                 .name("trebuc32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/verdan32.exe ")
+                .url("https://github.com/pushcx/corefonts/raw/master/verdan32.exe ")
                 .checksum("f5b93cedf500edc67502f116578123618c64a42a")
                 .name("verdan32.exe")
                 .get(),
 
             new Resource()
                 .wizard(wizard)
-                .url("https://mirrors.kernel.org/gentoo/distfiles/webdin32.exe ")
+                .url("https://github.com/pushcx/corefonts/raw/master/webdin32.exe ")
                 .checksum("2fb4a42c53e50bc70707a7b3c57baf62ba58398f")
                 .name("webdin32.exe")
                 .get()


### PR DESCRIPTION
The URLs in the Wine corefonts verb didn't work anymore.

Use URLs from winetricks.

Fixes https://github.com/PhoenicisOrg/phoenicis/issues/2785.
